### PR TITLE
feat(2.31.0): cross-project tools - c3_project MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.31.0] - 2026-06-09
+
+Feature release. C3 tools can now reach **outside the current workspace** to
+discover and operate on *other* c3-installed projects. A new `c3_project` MCP
+tool lists/scans for projects that have a `.c3` directory and proxies the core
+C3 operations (search, read, compress, status, memory, impact, edits, validate,
+filter) against any of them — plus guarded writes (`edit`, `shell`, memory
+mutations) behind an explicit `allow_write=true`.
+
+### Added
+
+- `services/project_runtime.py` — shared, thread-safe `ProjectRuntimeCache`
+  (LRU, `.c3`-validated) that builds one `C3Runtime` per foreign project via the
+  existing `build_runtime`; plus `resolve_project()` (name-or-path resolution
+  against the global registry) and `scan_for_c3()` / `discover_projects()`
+  (registry + bounded filesystem scan for unregistered `.c3` projects).
+- `cli/tools/project.py` and the `c3_project` MCP tool — action-dispatch surface:
+  discovery (`list`, `scan`, `info`, `register`, `unregister`), read ops
+  (`search`, `read`, `compress`, `status`, `memory`, `impact`, `edits`,
+  `validate`, `filter`), and guarded write ops (`edit`, `shell`, memory
+  `add/update/delete`). Foreign mutations are logged to the *target* project's
+  activity log and edit ledger.
+- `mcp__c3__c3_project` added to `_C3_MCP_ALLOW` in `cli/c3.py`.
+- `tests/test_project_tool.py` covering the resolver, discovery, runtime-cache
+  LRU/validation, and the dispatcher (read proxy + write guard + audit).
+
+### Changed
+
+- `__version__` in `cli/c3.py` and `version` in `pyproject.toml` bumped to
+  `2.31.0` (kept in sync).
+
+### Why
+
+Until now every C3 capability was scoped to the single project the MCP server
+was launched in. Cross-project work meant switching workspaces. `c3_project`
+lets an agent stay in one session, see which sibling projects have C3 installed,
+and search/read/edit across them — while keeping writes explicit and auditable
+on the project they land in.
+
 ## [2.30.0] - 2026-05-07
 
 Feature release. Adds first-class Bitbucket Data Center / Server (self-hosted

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Per-project knobs for everything: budget thresholds, feature flag mode, edit led
 
 ## The MCP tool suite
 
-C3 exposes 15 tools as a native MCP server. Your IDE calls them directly:
+C3 exposes 16 tools as a native MCP server. Your IDE calls them directly:
 
 | Tool | What it does |
 |---|---|
@@ -185,8 +185,9 @@ C3 exposes 15 tools as a native MCP server. Your IDE calls them directly:
 | `c3_agent` | Multi-step agentic workflows (review, investigate, refactor) |
 | `c3_edits` | Edit-ledger queries + version diffs + restore points |
 | `c3_bitbucket` | Bitbucket Data Center integration — PRs, branches, builds, repo admin (v2.30.0) |
+| `c3_project` | Cross-project — discover & operate on other c3-installed projects; guarded writes (v2.31.0) |
 
-Every tool is **read-only safe in plan mode** (except `c3_edit`, `c3_shell`, and write actions on `c3_bitbucket`).
+Every tool is **read-only safe in plan mode** (except `c3_edit`, `c3_shell`, and write actions on `c3_bitbucket` / `c3_project`).
 
 ### Bitbucket Data Center / Server (v2.30.0)
 

--- a/cli/c3.py
+++ b/cli/c3.py
@@ -85,7 +85,7 @@ console = Console() if HAS_RICH else None
 # Config
 CONFIG_DIR = ".c3"
 CONFIG_FILE = ".c3/config.json"
-__version__ = "2.30.0"
+__version__ = "2.31.0"
 
 
 def _command_deps() -> CommandDeps:
@@ -239,6 +239,7 @@ _C3_MCP_ALLOW = [
     "mcp__c3__c3_memory", "mcp__c3__c3_validate", "mcp__c3__c3_edit",
     "mcp__c3__c3_agent", "mcp__c3__c3_delegate", "mcp__c3__c3_edits",
     "mcp__c3__c3_impact", "mcp__c3__c3_shell", "mcp__c3__c3_bitbucket",
+    "mcp__c3__c3_project",
 ]
 
 # Obsolete MCP tool names from earlier C3 versions. `c3 permissions clean`
@@ -4492,6 +4493,7 @@ back to native tools as the task progresses.
 - **Memory**: `c3_memory(action='recall')` — full recall. `index` + `fetch` for token-efficient two-step retrieval
 - **Delegate**: `c3_delegate(task, backend='ollama|codex|gemini|claude|auto')` — offload to other models
 - **Bitbucket** (v2.30.0+, when `c3 bitbucket login` has run): `c3_bitbucket(action='list_prs|get_pr|merge_pr|...')` — self-hosted Bitbucket Data Center / Server. Token in OS keyring; mutating actions auto-log to the edit ledger.
+- **Cross-project** (v2.31.0+): `c3_project(action='list|scan|search|read|edit|...', project='<name|path>')` — discover and operate on OTHER c3-installed projects. Reads run freely; writes (edit/shell/memory) need `allow_write=true`.
 
 ## Self-Check
 If you haven't called a c3_* tool in several turns during active development, re-engage

--- a/cli/docs.html
+++ b/cli/docs.html
@@ -1148,7 +1148,7 @@ python cli/c3.py install-mcp . gemini</code></pre>
 
       <!-- â”€â”€â”€ MCP Tools â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ -->
       <h2 id="mcp-tools">MCP Tools Reference</h2>
-      <p>C3 exposes 15 MCP tools. All core tools work without Ollama; delegate requires it. The Bitbucket integration is optional and activated via <code>c3 bitbucket login</code>.</p>
+      <p>C3 exposes 16 MCP tools. All core tools work without Ollama; delegate requires it. The Bitbucket integration is optional and activated via <code>c3 bitbucket login</code>.</p>
 
       <h3>Discovery &amp; Compression</h3>
       <table>

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -699,6 +699,65 @@ async def c3_bitbucket(
     )
 
 
+@mcp.tool()
+async def c3_project(
+    action: str,
+    project: str = "",
+    query: str = "",
+    file_path: str = "",
+    symbols: Any = None,
+    lines: Any = None,
+    mode: str = "map",
+    view: str = "health",
+    top_k: int = 5,
+    max_tokens: int = 1200,
+    search_action: str = "code",
+    mem_action: str = "recall",
+    fact: str = "",
+    category: str = "",
+    fact_id: str = "",
+    edits_action: str = "history",
+    file: str = "",
+    tag: str = "",
+    limit: int = 50,
+    target: str = "",
+    old_string: str = "",
+    new_string: str = "",
+    summary: str = "",
+    edits: str = "",
+    replace_all: bool = False,
+    tags: str = "",
+    cmd: str = "",
+    timeout: int = 60,
+    scan_roots: str = "",
+    allow_write: bool = False,
+    ctx: Context = None,
+) -> str:
+    """CROSS-PROJECT — run C3 against OTHER c3-installed projects (read-only safe in plan mode).
+    Discover: list (registry), scan (registry+filesystem), info, register, unregister.
+    Read    : search, read, compress, status, memory, impact, edits, validate, filter.
+    Write   : edit, shell, memory(add/update/delete) — require allow_write=true; logged to that project's ledger.
+    project = registered name OR absolute path (.c3 required). list/scan need no project.
+    search_action/mem_action/edits_action pick the sub-op for those verbs."""
+    svc = _svc(ctx)
+
+    def finalize(fname, fargs, fresp, fsumm, **kw):
+        return _finalize_response(ctx, fname, fargs, fresp, fsumm, **kw)
+
+    from cli.tools.project import handle_project
+    return await asyncio.to_thread(
+        handle_project, action, svc, finalize,
+        project=project, query=query, file_path=file_path, symbols=symbols,
+        lines=lines, mode=mode, view=view, top_k=top_k, max_tokens=max_tokens,
+        search_action=search_action, mem_action=mem_action, fact=fact,
+        category=category, fact_id=fact_id, edits_action=edits_action, file=file,
+        tag=tag, limit=limit, target=target, old_string=old_string,
+        new_string=new_string, summary=summary, edits=edits,
+        replace_all=replace_all, tags=tags, cmd=cmd, timeout=timeout,
+        scan_roots=scan_roots, allow_write=allow_write,
+    )
+
+
 def main() -> None:
     """Entry-point for the ``c3-mcp`` console script."""
     from services import error_reporting

--- a/cli/tools/project.py
+++ b/cli/tools/project.py
@@ -1,0 +1,287 @@
+"""c3_project tool -- run C3 against OTHER c3-installed projects.
+
+Discovery and read ops run freely against any registered/.c3 project. Write ops
+(``edit``, ``shell``, and memory mutations) require ``allow_write=True`` and are
+recorded on the *target* project (its edit ledger + activity log), so a foreign
+mutation leaves an audit trail in the project it touched.
+
+The heavy lifting reuses the existing per-tool handlers unchanged -- only the
+``svc`` (a ``C3Runtime``) differs, supplied by the shared foreign-runtime cache.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from services.project_runtime import (
+    discover_projects,
+    resolve_project,
+    shared_cache,
+)
+
+# Memory sub-actions that mutate the target project's fact store.
+_MEMORY_WRITE = {"add", "update", "delete", "consolidate", "consolidate_deep", "ground"}
+# Dispatch verbs that mutate the target project.
+_WRITE_OPS = {"edit", "shell"}
+_DISCOVERY_OPS = {"list", "scan", "info", "register", "unregister"}
+_READ_OPS = {
+    "search", "read", "compress", "status", "memory",
+    "impact", "edits", "validate", "filter",
+}
+
+
+def _foreign_finalize(_name, _args, resp, _summ="", **_kw):
+    """No-op finalize for proxied calls.
+
+    The home session's finalize wraps the whole ``c3_project`` response, so the
+    inner handlers must not also charge budget / log against either session.
+    """
+    return resp
+
+
+def _foreign_facts(*_a, **_kw):
+    return ""
+
+
+def _runtime_for(path: str):
+    """Indirection point (monkeypatched in tests) -> foreign ``C3Runtime``."""
+    return shared_cache().get(path)
+
+
+# ── Discovery renderers ────────────────────────────────────────────────────
+
+
+def _render_discovery(scan_roots_csv: str, do_scan: bool) -> str:
+    roots = [r.strip() for r in (scan_roots_csv or "").split(",") if r.strip()] or None
+    data = discover_projects(scan_roots=roots, scan=do_scan)
+    reg = data["registered"]
+    unreg = data["unregistered"]
+
+    out = [f"Registered C3 projects ({len(reg)}):"]
+    if not reg:
+        out.append("  (none -- c3_project(action='register', project='<path>') to add one)")
+    for p in reg:
+        flag = "" if p["accessible"] else "  [MISSING]"
+        out.append(f"  - {p['name']:<28} {p['ide']:<12} {p['path']}{flag}")
+
+    if do_scan:
+        out.append("")
+        out.append(f"Unregistered .c3 projects found nearby ({len(unreg)}):")
+        if not unreg:
+            out.append("  (none found near registered projects)")
+        for p in unreg:
+            out.append(f"  - {p['name']:<28} {'':<12} {p['path']}")
+        if unreg:
+            out.append("")
+            out.append("Register one: c3_project(action='register', project='<path>')")
+    return "\n".join(out)
+
+
+def _render_info(project: str) -> str:
+    try:
+        resolved = resolve_project(project)
+    except ValueError as e:
+        return f"[c3_project:error] {e}"
+    p = Path(resolved["path"])
+    out = [
+        f"Project: {resolved['name']}",
+        f"  path        : {resolved['path']}",
+        f"  .c3 present : {(p / '.c3').is_dir()}",
+        f"  accessible  : {p.is_dir()}",
+    ]
+    try:
+        from services.project_manager import ProjectManager
+
+        details = ProjectManager().get_project_details(resolved["path"]) or {}
+        for key in ("ide", "c3_version", "facts_count", "last_session", "active"):
+            if key in details and details[key] not in (None, ""):
+                out.append(f"  {key:<11} : {details[key]}")
+    except Exception:
+        pass
+    return "\n".join(out)
+
+
+def _do_register(project: str) -> str:
+    if not (project or "").strip():
+        return "[c3_project:error] register requires project='<path>'."
+    path = Path(project).expanduser()
+    if not path.exists():
+        return f"[c3_project:error] Path does not exist: {project}"
+    if not (path / ".c3").is_dir():
+        return (
+            f"[c3_project:error] No .c3 directory in {path}. "
+            "Run 'c3 init' there first."
+        )
+    from services.project_manager import ProjectManager
+
+    entry = ProjectManager().add_project(str(path.resolve()))
+    return f"Registered: {entry['name']}  ({entry['path']})"
+
+
+def _do_unregister(project: str) -> str:
+    try:
+        resolved = resolve_project(project)
+    except ValueError as e:
+        return f"[c3_project:error] {e}"
+    from services.project_manager import ProjectManager
+
+    removed = ProjectManager().remove_project(resolved["path"])
+    return (
+        f"Unregistered: {resolved['name']}"
+        if removed
+        else f"Not in registry: {resolved['name']}"
+    )
+
+
+# ── Proxied op dispatch ────────────────────────────────────────────────────
+
+
+def _proxy(action, fsvc, *, query, file_path, symbols, lines, mode, view, top_k,
+           max_tokens, search_action, mem_action, fact, category, fact_id,
+           edits_action, file, tag, limit, target, old_string, new_string,
+           summary, edits, replace_all, tags, cmd, timeout, project_path):
+    if action == "search":
+        from cli.tools.search import handle_search
+
+        return handle_search(query, search_action, top_k, max_tokens,
+                             fsvc, _foreign_finalize, _foreign_facts)
+    if action == "read":
+        from cli.tools.read import handle_read
+
+        return handle_read(file_path, symbols=symbols, lines=lines,
+                           svc=fsvc, finalize=_foreign_finalize)
+    if action == "compress":
+        from cli.tools.compress import handle_compress
+
+        return handle_compress(file_path, mode, fsvc, _foreign_finalize, _foreign_facts)
+    if action == "status":
+        from cli.tools.status import handle_status
+
+        return handle_status(view, False, fsvc, _foreign_finalize)
+    if action == "memory":
+        from cli.tools.memory import handle_memory
+
+        return handle_memory(mem_action, query, fact, category, top_k,
+                            fsvc, _foreign_finalize, fact_id=fact_id)
+    if action == "impact":
+        from cli.tools.impact import handle_impact
+
+        imode = mode if mode in ("symbol", "unstaged") else "symbol"
+        return handle_impact(target, file_path, imode, fsvc, _foreign_finalize)
+    if action == "edits":
+        from cli.tools.edits import handle_edits
+
+        return handle_edits(edits_action, file, "", "", "", tags, limit, "", "",
+                           tag, fsvc, _foreign_finalize)
+    if action == "validate":
+        from cli.tools.validate import handle_validate
+
+        return asyncio.run(handle_validate(file_path, fsvc, _foreign_finalize))
+    if action == "filter":
+        from cli.tools.filter import handle_filter
+
+        return handle_filter(file_path, "", query, 100, "smart", False,
+                           fsvc, _foreign_finalize)
+    if action == "edit":
+        from cli.tools.edit import handle_edit
+
+        return handle_edit(file_path, old_string, new_string, summary, tags,
+                          replace_all, fsvc, _foreign_finalize, edits)
+    if action == "shell":
+        from cli.tools.shell import handle_shell
+
+        return asyncio.run(handle_shell(cmd, project_path, timeout, True, True,
+                                       fsvc, _foreign_finalize))
+    return f"[c3_project:error] Unhandled op '{action}'."
+
+
+# ── Entry point ────────────────────────────────────────────────────────────
+
+
+def handle_project(action, svc, finalize, *, project="", query="", file_path="",
+                   symbols=None, lines=None, mode="map", view="health", top_k=5,
+                   max_tokens=1200, search_action="code", mem_action="recall",
+                   fact="", category="", fact_id="", edits_action="history",
+                   file="", tag="", limit=50, target="", old_string="",
+                   new_string="", summary="", edits="", replace_all=False,
+                   tags="", cmd="", timeout=60, scan_roots="", allow_write=False):
+    action = (action or "").strip().lower()
+
+    def done(resp, summ="ok"):
+        return finalize("c3_project", {"action": action, "project": project},
+                        resp, summ)
+
+    if not action:
+        return done(
+            "[c3_project:error] action required. "
+            f"Discovery: {', '.join(sorted(_DISCOVERY_OPS))}. "
+            f"Read: {', '.join(sorted(_READ_OPS))}. "
+            f"Write (allow_write=true): {', '.join(sorted(_WRITE_OPS))}.",
+            "error")
+
+    # ── Discovery (no foreign runtime needed) ──────────────────────────
+    if action in ("list", "scan"):
+        return done(_render_discovery(scan_roots, action == "scan"), f"{action} projects")
+    if action == "info":
+        return done(_render_info(project), "project info")
+    if action == "register":
+        return done(_do_register(project), "register project")
+    if action == "unregister":
+        return done(_do_unregister(project), "unregister project")
+
+    if action not in _READ_OPS and action not in _WRITE_OPS:
+        return done(
+            f"[c3_project:error] Unknown action '{action}'. "
+            f"Discovery: {', '.join(sorted(_DISCOVERY_OPS))}. "
+            f"Read: {', '.join(sorted(_READ_OPS))}. "
+            f"Write (allow_write=true): {', '.join(sorted(_WRITE_OPS))}.",
+            "error")
+
+    # ── Write guard ────────────────────────────────────────────────────
+    is_write = action in _WRITE_OPS or (
+        action == "memory" and (mem_action or "").lower() in _MEMORY_WRITE
+    )
+    if is_write and not allow_write:
+        label = action + (f"/{mem_action}" if action == "memory" else "")
+        return done(
+            f"[c3_project:blocked] '{label}' would modify project '{project}'. "
+            "Re-run with allow_write=true to proceed.",
+            "blocked")
+
+    # ── Resolve + borrow the foreign runtime ───────────────────────────
+    try:
+        resolved = resolve_project(project)
+    except ValueError as e:
+        return done(f"[c3_project:error] {e}", "error")
+    try:
+        fsvc = _runtime_for(resolved["path"])
+    except Exception as e:
+        return done(
+            f"[c3_project:error] Could not load '{resolved['name']}': {e}", "error")
+
+    banner = f"[c3_project:{resolved['name']}] {action}\n"
+    try:
+        body = _proxy(
+            action, fsvc, query=query, file_path=file_path, symbols=symbols,
+            lines=lines, mode=mode, view=view, top_k=top_k, max_tokens=max_tokens,
+            search_action=search_action, mem_action=mem_action, fact=fact,
+            category=category, fact_id=fact_id, edits_action=edits_action,
+            file=file, tag=tag, limit=limit, target=target, old_string=old_string,
+            new_string=new_string, summary=summary, edits=edits,
+            replace_all=replace_all, tags=tags, cmd=cmd, timeout=timeout,
+            project_path=resolved["path"],
+        )
+    except Exception as e:
+        return done(f"{banner}[error] {type(e).__name__}: {e}", "error")
+
+    # Audit foreign mutations on the target project itself.
+    if is_write and getattr(fsvc, "activity_log", None):
+        try:
+            fsvc.activity_log.log("cross_project_write", {
+                "action": action,
+                "from_project": getattr(svc, "project_path", ""),
+            })
+        except Exception:
+            pass
+
+    return done(banner + (body or ""), f"{action} on {resolved['name']}")

--- a/guide/index.html
+++ b/guide/index.html
@@ -305,7 +305,7 @@
       <a href="tools.html" class="nav-card">
         <span class="nav-card-icon">🔧</span>
         <div class="nav-card-title">Tools Reference</div>
-        <div class="nav-card-desc">Full reference for all 15 MCP tools — params, examples, notes</div>
+        <div class="nav-card-desc">Full reference for all 16 MCP tools — params, examples, notes</div>
       </a>
       <a href="bitbucket.html" class="nav-card">
         <span class="nav-card-icon">🪣</span>

--- a/guide/tools.html
+++ b/guide/tools.html
@@ -122,6 +122,10 @@
       <div class="sidebar-label">SCM</div>
       <a href="#c3_bitbucket" class="sidebar-link"><span class="icon">🪣</span> c3_bitbucket</a>
     </div>
+    <div class="sidebar-section">
+      <div class="sidebar-label">Cross-project</div>
+      <a href="#c3_project" class="sidebar-link"><span class="icon">🗂️</span> c3_project</a>
+    </div>
   </aside>
 
   <!-- Main -->
@@ -129,7 +133,7 @@
 
     <div class="page-hero">
       <h1>Tools Reference</h1>
-      <p>Complete reference for all 15 C3 MCP tools — parameters, actions, examples, and usage notes.</p>
+      <p>Complete reference for all 16 C3 MCP tools — parameters, actions, examples, and usage notes.</p>
     </div>
 
     <!-- TOC -->
@@ -151,6 +155,7 @@
         <a href="#c3_agent"    class="toc-item">c3_agent    <span class="cat">AI</span></a>
         <a href="#c3_edits"    class="toc-item">c3_edits    <span class="cat">Ledger</span></a>
         <a href="#c3_bitbucket" class="toc-item">c3_bitbucket <span class="cat">SCM</span></a>
+        <a href="#c3_project"  class="toc-item">c3_project  <span class="cat">Multi-project</span></a>
       </div>
     </div>
 
@@ -1123,6 +1128,60 @@ c3_bitbucket(action=<span class="str">'approve_pr'</span>, pr_id=<span class="nu
 c3_bitbucket(action=<span class="str">'merge_pr'</span>, pr_id=<span class="num">42</span>)</code></pre>
 
           <p class="tool-desc"><strong>Audit trail:</strong> mutating actions (<code>merge_pr</code>, <code>create_branch</code>, <code>delete_branch</code>, webhook writes, etc.) are appended to the C3 edit ledger so the local audit log covers platform-side state changes too.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════ CROSS-PROJECT ═════ -->
+    <div class="tool-section">
+      <div class="tool-section-label">Cross-project</div>
+
+      <!-- c3_project -->
+      <div class="tool-card" id="c3_project">
+        <div class="tool-card-header">
+          <span class="tool-name">c3_project</span>
+          <div class="tag-row">
+            <span class="badge badge-purple">multi-project</span>
+            <span class="badge">v2.31.0</span>
+          </div>
+          <span class="tool-tagline">Run C3 against OTHER c3-installed projects — discover, read, and (guarded) write</span>
+        </div>
+        <div class="tool-card-body">
+          <p class="tool-desc">Reach outside the current workspace. C3 keeps a global registry of installed projects (<code>~/.c3/projects.json</code>); <code>c3_project</code> lists/scans them and proxies the core C3 operations against any one — building and caching a full runtime per target project on demand. Name the target by registered <strong>name</strong> or absolute <strong>path</strong> (a <code>.c3</code> directory is required).</p>
+
+          <p class="tool-desc"><strong>Write safety:</strong> read ops run freely; mutating ops (<code>edit</code>, <code>shell</code>, and memory <code>add/update/delete</code>) are refused unless you pass <code>allow_write=true</code>, and every foreign mutation is recorded on the <em>target</em> project's activity log and edit ledger.</p>
+
+          <h4>Actions</h4>
+          <table class="params-table">
+            <thead><tr><th>Action</th><th>Group</th><th>Description</th></tr></thead>
+            <tbody>
+              <tr><td class="param-name">list</td><td>Discover</td><td class="param-desc">Registered projects (fast; registry only)</td></tr>
+              <tr><td class="param-name">scan</td><td>Discover</td><td class="param-desc">Registry + bounded filesystem scan for unregistered <code>.c3</code> projects nearby</td></tr>
+              <tr><td class="param-name">info, register, unregister</td><td>Discover</td><td class="param-desc">Project details / add to / remove from the registry</td></tr>
+              <tr><td class="param-name">search, read, compress, status, memory, impact, edits, validate, filter</td><td>Read</td><td class="param-desc">Proxy the matching c3_* tool against the target project</td></tr>
+              <tr><td class="param-name">edit, shell, memory(add/update/delete)</td><td>Write</td><td class="param-desc">Mutate the target project — require <code>allow_write=true</code></td></tr>
+            </tbody>
+          </table>
+
+          <h4>Examples</h4>
+          <pre><code><span class="com"># Which projects have C3 installed?</span>
+c3_project(action=<span class="str">'list'</span>)
+c3_project(action=<span class="str">'scan'</span>)              <span class="com"># also finds unregistered .c3 dirs nearby</span>
+
+<span class="com"># Search / read inside another project</span>
+c3_project(action=<span class="str">'search'</span>, project=<span class="str">'SafeMirror'</span>, query=<span class="str">'token bucket'</span>)
+c3_project(action=<span class="str">'read'</span>, project=<span class="str">'SafeMirror'</span>, file_path=<span class="str">'core/limiter.py'</span>, symbols=<span class="str">'RateLimiter'</span>)
+
+<span class="com"># Memory recall from another project's fact store</span>
+c3_project(action=<span class="str">'memory'</span>, project=<span class="str">'Sentinel'</span>, mem_action=<span class="str">'recall'</span>, query=<span class="str">'auth flow'</span>)
+
+<span class="com"># Guarded write — the edit lands in the target project's ledger</span>
+c3_project(action=<span class="str">'edit'</span>, project=<span class="str">'Sentinel'</span>,
+           file_path=<span class="str">'README.md'</span>,
+           old_string=<span class="str">'v1'</span>, new_string=<span class="str">'v2'</span>,
+           allow_write=<span class="num">true</span>)</code></pre>
+
+          <p class="tool-desc"><strong>Sub-action params:</strong> <code>search_action</code> (code/files/semantic/…), <code>mem_action</code> (recall/index/fetch/add/…), and <code>edits_action</code> (history/versions/stats) pick the operation for those verbs; <code>scan_roots</code> (comma-separated) overrides where <code>scan</code> looks.</p>
         </div>
       </div>
     </div>

--- a/guide/workflow.html
+++ b/guide/workflow.html
@@ -347,6 +347,12 @@
             <td><code>c3_bitbucket(action='list_prs')</code></td>
             <td>v2.30.0 — see/act on PRs, branches, builds, repo admin on enterprise Bitbucket Data Center. <a href="bitbucket.html">Full guide →</a></td>
           </tr>
+          <tr>
+            <td><span class="badge badge-purple">+</span></td>
+            <td><strong>Cross-project</strong></td>
+            <td><code>c3_project(action='list')</code></td>
+            <td>v2.31.0 — discover and operate on OTHER c3-installed projects; reads run free, writes need <code>allow_write=true</code>. <a href="tools.html#c3_project">Tool card →</a></td>
+          </tr>
         </tbody>
       </table>
     </section>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "code-context-control"
-version = "2.30.0"
+version = "2.31.0"
 description = "Local code-intelligence layer for AI coding tools (Claude Code, Codex, Gemini, Copilot). Retrieve less, read less, edit safer."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/services/claude_md.py
+++ b/services/claude_md.py
@@ -41,6 +41,7 @@ When falling back, state which c3_* tool was attempted and why it was insufficie
 8. **LOG**: `c3_session(action='log')` for decisions. `c3_session(action='snapshot')` before /clear
 9. **DELEGATE**: `c3_delegate(task, backend='ollama|codex|gemini|claude|auto')` or `c3_agent(workflow=...)` for multi-model pipelines
 10. **BITBUCKET** (when configured, v2.30.0+): `c3_bitbucket(action='...')` — for self-hosted enterprise Bitbucket Data Center / Server: PRs, branches, builds, repo admin. Tokens live in the OS keyring (set up via `c3 bitbucket login`). Read actions are safe in plan mode; write actions (`merge_pr`, `create_branch`, etc.) are auto-logged to the edit ledger.
+11. **CROSS-PROJECT** (v2.31.0+): `c3_project(action='list|scan|info|search|read|edit|shell|...', project='<name|path>')` — discover and operate on OTHER c3-installed projects. `list`/`scan` need no project; reads (search/read/compress/status/memory/impact/edits/validate/filter) run freely; writes (`edit`, `shell`, memory add/update/delete) require `allow_write=true` and are logged to the target project's ledger.
 
 ## Plan mode
 In plan mode, all c3_* read tools (search, read, compress, filter, validate, status) work normally — skip edit/delegate steps.

--- a/services/project_runtime.py
+++ b/services/project_runtime.py
@@ -1,0 +1,291 @@
+"""Shared cross-project runtime cache, resolution, and discovery.
+
+Lets C3 tools operate on *other* c3-installed projects without launching a
+separate MCP server per project. A full ``C3Runtime`` is built and cached per
+project path (LRU) via ``services.runtime.build_runtime`` -- the exact builder
+the MCP server and web server already use.
+
+This is the shared home for the per-project runtime cache; the Oracle's
+``C3Bridge`` predates it and keeps its own cache for now.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Optional
+
+from services.runtime import C3Runtime, build_runtime, stop_runtime
+
+# Global registry written by ProjectManager (~/.c3/projects.json).
+_GLOBAL_C3_DIR = Path.home() / ".c3"
+_PROJECTS_FILE = _GLOBAL_C3_DIR / "projects.json"
+
+# Filesystem scan tuning -- bounded so a sweep over large roots stays cheap.
+_SCAN_MAX_DEPTH = 4
+_SCAN_SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv", "env",
+    ".c3", ".mypy_cache", ".ruff_cache", ".pytest_cache", ".tox",
+    "dist", "build", "site-packages", ".idea", ".vscode", ".next",
+    "target", ".gradle", ".cargo", "vendor",
+}
+
+
+# ── Runtime cache ──────────────────────────────────────────────────────────
+
+
+class ProjectRuntimeCache:
+    """Thread-safe LRU cache of ``C3Runtime`` objects keyed by resolved path.
+
+    Lifted from ``oracle.services.c3_bridge.C3Bridge.get_runtime`` so the MCP
+    server and any other caller share one implementation.
+    """
+
+    def __init__(self, ide_name: str = "claude-code", max_cached: int = 4):
+        self._ide_name = ide_name
+        self._max = max(1, int(max_cached))
+        self._runtimes: dict[str, C3Runtime] = {}
+        self._order: list[str] = []
+        self._lock = threading.Lock()
+
+    def get(self, project_path: str) -> C3Runtime:
+        """Return a cached runtime or build one. Raises ValueError if invalid."""
+        project_path = str(Path(project_path).resolve())
+        with self._lock:
+            rt = self._runtimes.get(project_path)
+            if rt is not None:
+                self._touch_locked(project_path)
+                return rt
+
+        # Validate outside the lock (don't hold it across disk checks / build).
+        p = Path(project_path)
+        if not p.exists():
+            raise ValueError(f"Project path does not exist: {project_path}")
+        if not (p / ".c3").is_dir():
+            raise ValueError(
+                f"No .c3 directory in {project_path}. Run 'c3 init' there first."
+            )
+
+        runtime = build_runtime(project_path, ide_name=self._ide_name)
+
+        with self._lock:
+            # Another thread may have built it while we were unlocked.
+            existing = self._runtimes.get(project_path)
+            if existing is not None:
+                stop_runtime(runtime)
+                self._touch_locked(project_path)
+                return existing
+            self._runtimes[project_path] = runtime
+            self._order.append(project_path)
+            while len(self._order) > self._max:
+                evict = self._order.pop(0)
+                old = self._runtimes.pop(evict, None)
+                if old is not None:
+                    stop_runtime(old)
+        return runtime
+
+    def _touch_locked(self, path: str) -> None:
+        if path in self._order:
+            self._order.remove(path)
+        self._order.append(path)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            for rt in self._runtimes.values():
+                stop_runtime(rt)
+            self._runtimes.clear()
+            self._order.clear()
+
+
+_shared_cache: Optional[ProjectRuntimeCache] = None
+_shared_lock = threading.Lock()
+
+
+def shared_cache() -> ProjectRuntimeCache:
+    """Return the process-wide foreign-runtime cache (lazily created)."""
+    global _shared_cache
+    if _shared_cache is None:
+        with _shared_lock:
+            if _shared_cache is None:
+                _shared_cache = ProjectRuntimeCache()
+    return _shared_cache
+
+
+# ── Registry access ────────────────────────────────────────────────────────
+
+
+def _read_registry() -> list[dict]:
+    try:
+        if _PROJECTS_FILE.exists():
+            with open(_PROJECTS_FILE, encoding="utf-8") as f:
+                return json.load(f).get("projects", [])
+    except Exception:
+        pass
+    return []
+
+
+def _norm(name: str) -> str:
+    """Case/space/punctuation-insensitive key for fuzzy name matching."""
+    return "".join(ch for ch in (name or "").lower() if ch.isalnum())
+
+
+def _resolved(path: str) -> str:
+    try:
+        return str(Path(path).expanduser().resolve())
+    except Exception:
+        return path or ""
+
+
+# ── Resolution ─────────────────────────────────────────────────────────────
+
+
+def resolve_project(ref: str) -> dict:
+    """Resolve a project *name or path* to ``{"name", "path"}``.
+
+    Resolution order: a real path containing ``.c3`` > exact registry path >
+    exact registry name > unique substring name match. Raises ``ValueError``
+    with an actionable message when the reference is unknown or ambiguous.
+    """
+    if not ref or not ref.strip():
+        raise ValueError("No project specified -- pass a registered name or a path.")
+    ref = ref.strip()
+    registry = _read_registry()
+
+    # 1. A path on disk that is itself a C3 project (registered or not).
+    candidate = Path(ref).expanduser()
+    if candidate.exists() and (candidate / ".c3").is_dir():
+        resolved = str(candidate.resolve())
+        match = next(
+            (p for p in registry if _resolved(p.get("path", "")) == resolved), None
+        )
+        return {
+            "name": (match or {}).get("name") or candidate.name,
+            "path": resolved,
+        }
+
+    # 2. Exact path match in the registry (path may be stale on disk).
+    ref_resolved = _resolved(ref)
+    for p in registry:
+        if _resolved(p.get("path", "")) == ref_resolved:
+            return {
+                "name": p.get("name") or Path(p["path"]).name,
+                "path": _resolved(p["path"]),
+            }
+
+    # 3. Name match: exact (normalized) first, then unique substring.
+    nref = _norm(ref)
+    exact = [p for p in registry if _norm(p.get("name", "")) == nref]
+    if len(exact) == 1:
+        return {"name": exact[0]["name"], "path": _resolved(exact[0]["path"])}
+    if len(exact) > 1:
+        raise ValueError(
+            f"Ambiguous project name '{ref}' -- {len(exact)} registered projects "
+            "share it. Pass an absolute path instead."
+        )
+
+    partial = [p for p in registry if nref and nref in _norm(p.get("name", ""))]
+    if len(partial) == 1:
+        return {"name": partial[0]["name"], "path": _resolved(partial[0]["path"])}
+    if len(partial) > 1:
+        names = ", ".join(p.get("name", "?") for p in partial[:8])
+        raise ValueError(
+            f"Ambiguous project '{ref}' -- matches: {names}. "
+            "Be more specific or pass a path."
+        )
+
+    known = ", ".join(p.get("name", "?") for p in registry[:12]) or "(none registered)"
+    raise ValueError(
+        f"Unknown project '{ref}'. Registered: {known}. "
+        "Or pass an absolute path to a folder that contains a .c3 directory."
+    )
+
+
+# ── Discovery (registry + filesystem scan) ─────────────────────────────────
+
+
+def scan_for_c3(roots: list[str], max_depth: int = _SCAN_MAX_DEPTH) -> list[str]:
+    """Walk ``roots`` (bounded depth) and return folders containing a ``.c3`` dir.
+
+    Once a project is found its subtree is not descended -- nested ``.c3`` dirs
+    inside a project are ignored.
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+    for root in roots or []:
+        base = Path(root).expanduser()
+        if not base.is_dir():
+            continue
+        base_parts = len(base.resolve().parts)
+        for dirpath, dirnames, _files in os.walk(base):
+            here = Path(dirpath)
+            depth = len(here.resolve().parts) - base_parts
+            if depth >= max_depth:
+                dirnames[:] = []
+            else:
+                dirnames[:] = [d for d in dirnames if d not in _SCAN_SKIP_DIRS]
+            if (here / ".c3").is_dir():
+                rp = str(here.resolve())
+                if rp not in seen:
+                    seen.add(rp)
+                    found.append(rp)
+                dirnames[:] = []  # don't descend into a project's children
+    return found
+
+
+def default_scan_roots() -> list[str]:
+    """Parent directories of registered projects -- a cheap, useful default.
+
+    Scanning the parents of known projects surfaces sibling projects without
+    walking the whole filesystem.
+    """
+    roots: list[str] = []
+    seen: set[str] = set()
+    for p in _read_registry():
+        path = p.get("path", "")
+        if not path:
+            continue
+        parent = str(Path(path).expanduser().resolve().parent)
+        if parent and parent not in seen:
+            seen.add(parent)
+            roots.append(parent)
+    return roots
+
+
+def discover_projects(
+    scan_roots: Optional[list[str]] = None, scan: bool = True
+) -> dict:
+    """Return ``{"registered": [...], "unregistered": [...]}``.
+
+    ``registered`` comes from the global registry; ``unregistered`` are ``.c3``
+    projects found by scanning that are not in the registry yet.
+    """
+    registry = _read_registry()
+    reg_paths = {_resolved(p.get("path", "")) for p in registry if p.get("path")}
+
+    registered = [
+        {
+            "name": p.get("name") or Path(p.get("path", "")).name,
+            "path": _resolved(p.get("path", "")),
+            "ide": p.get("ide", "unknown"),
+            "registered": True,
+            "accessible": Path(p.get("path", "")).is_dir() if p.get("path") else False,
+        }
+        for p in registry
+    ]
+
+    unregistered: list[dict] = []
+    if scan:
+        roots = scan_roots if scan_roots is not None else default_scan_roots()
+        for path in scan_for_c3(roots):
+            if path not in reg_paths:
+                unregistered.append(
+                    {
+                        "name": Path(path).name,
+                        "path": path,
+                        "ide": "unknown",
+                        "registered": False,
+                        "accessible": True,
+                    }
+                )
+    return {"registered": registered, "unregistered": unregistered}

--- a/tests/test_project_tool.py
+++ b/tests/test_project_tool.py
@@ -1,0 +1,287 @@
+"""Tests for the cross-project tooling: resolver, discovery, runtime cache,
+and the c3_project dispatcher (read ops + write guard)."""
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from cli.tools import project as tool
+from services import project_runtime as pr
+
+
+def _make_c3_project(parent: Path, name: str) -> Path:
+    root = parent / name
+    (root / ".c3").mkdir(parents=True)
+    return root
+
+
+def _write_registry(path: Path, projects: list[dict]) -> None:
+    path.write_text(json.dumps({"projects": projects}), encoding="utf-8")
+
+
+def _captured_finalize():
+    seen: list[tuple] = []
+
+    def finalize(name, args, resp, summary, **kw):
+        seen.append((name, dict(args), resp, summary))
+        return resp
+
+    return finalize, seen
+
+
+class _StubActivity:
+    def __init__(self):
+        self.events: list[tuple] = []
+
+    def log(self, event_type, data):
+        self.events.append((event_type, data))
+
+
+class _StubSvc:
+    def __init__(self, project_path: str):
+        self.project_path = project_path
+        self.activity_log = _StubActivity()
+
+
+# ── Resolver ───────────────────────────────────────────────────────────────
+
+
+class TestResolveProject(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.reg_file = self.base / "projects.json"
+        self.proj = _make_c3_project(self.base, "Alpha Service")
+        _write_registry(self.reg_file, [
+            {"name": "Alpha Service", "path": str(self.proj), "ide": "claude-code"},
+            {"name": "Beta", "path": str(self.base / "beta_missing")},
+        ])
+        self._patch = mock.patch.object(pr, "_PROJECTS_FILE", self.reg_file)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        self._tmp.cleanup()
+
+    def test_resolve_by_path(self):
+        out = pr.resolve_project(str(self.proj))
+        self.assertEqual(out["path"], str(self.proj.resolve()))
+        self.assertEqual(out["name"], "Alpha Service")
+
+    def test_resolve_by_exact_name_normalized(self):
+        # Different case + spacing still matches.
+        out = pr.resolve_project("alphaservice")
+        self.assertEqual(out["path"], str(self.proj.resolve()))
+
+    def test_resolve_by_unique_substring(self):
+        out = pr.resolve_project("alpha")
+        self.assertEqual(out["name"], "Alpha Service")
+
+    def test_unknown_raises_with_registry_listing(self):
+        with self.assertRaises(ValueError) as cm:
+            pr.resolve_project("does-not-exist")
+        self.assertIn("Unknown project", str(cm.exception))
+        self.assertIn("Alpha Service", str(cm.exception))
+
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
+            pr.resolve_project("   ")
+
+
+# ── Discovery ──────────────────────────────────────────────────────────────
+
+
+class TestDiscovery(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.reg_file = self.base / "projects.json"
+        self.registered = _make_c3_project(self.base, "registered")
+        self.stray = _make_c3_project(self.base, "stray")  # not in registry
+        _make_c3_project(self.base, "deep_skip")  # also stray; both should appear
+        _write_registry(self.reg_file, [
+            {"name": "registered", "path": str(self.registered), "ide": "claude-code"},
+        ])
+        self._patch = mock.patch.object(pr, "_PROJECTS_FILE", self.reg_file)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        self._tmp.cleanup()
+
+    def test_scan_finds_c3_dirs(self):
+        found = pr.scan_for_c3([str(self.base)])
+        self.assertIn(str(self.registered.resolve()), found)
+        self.assertIn(str(self.stray.resolve()), found)
+
+    def test_scan_skips_noise_dirs(self):
+        noisy = self.base / "node_modules"
+        (noisy / "pkg" / ".c3").mkdir(parents=True)
+        found = pr.scan_for_c3([str(self.base)])
+        self.assertNotIn(str((noisy / "pkg").resolve()), found)
+
+    def test_discover_splits_registered_and_unregistered(self):
+        data = pr.discover_projects(scan_roots=[str(self.base)], scan=True)
+        reg_paths = {p["path"] for p in data["registered"]}
+        unreg_paths = {p["path"] for p in data["unregistered"]}
+        self.assertIn(str(self.registered.resolve()), reg_paths)
+        self.assertIn(str(self.stray.resolve()), unreg_paths)
+        self.assertNotIn(str(self.registered.resolve()), unreg_paths)
+
+    def test_discover_no_scan_returns_only_registered(self):
+        data = pr.discover_projects(scan=False)
+        self.assertEqual(data["unregistered"], [])
+        self.assertEqual(len(data["registered"]), 1)
+
+
+# ── Runtime cache ──────────────────────────────────────────────────────────
+
+
+class TestRuntimeCache(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_missing_path_raises(self):
+        cache = pr.ProjectRuntimeCache()
+        with self.assertRaises(ValueError):
+            cache.get(str(self.base / "nope"))
+
+    def test_no_c3_dir_raises(self):
+        plain = self.base / "plain"
+        plain.mkdir()
+        cache = pr.ProjectRuntimeCache()
+        with self.assertRaises(ValueError) as cm:
+            cache.get(str(plain))
+        self.assertIn(".c3", str(cm.exception))
+
+    def test_caches_and_evicts_lru(self):
+        p1 = _make_c3_project(self.base, "p1")
+        p2 = _make_c3_project(self.base, "p2")
+        p3 = _make_c3_project(self.base, "p3")
+        built: list[str] = []
+        stopped: list[object] = []
+
+        def fake_build(path, ide_name=None):
+            built.append(path)
+            return f"RT::{path}"
+
+        with mock.patch.object(pr, "build_runtime", side_effect=fake_build), \
+             mock.patch.object(pr, "stop_runtime", side_effect=stopped.append):
+            cache = pr.ProjectRuntimeCache(max_cached=2)
+            rt1 = cache.get(str(p1))
+            cache.get(str(p2))
+            # Re-access p1 so p2 becomes the LRU victim.
+            self.assertIs(cache.get(str(p1)), rt1)
+            cache.get(str(p3))  # evicts p2
+            # p2 was stopped on eviction; p1 stayed cached (no rebuild).
+            self.assertEqual(stopped, ["RT::" + str(p2.resolve())])
+            self.assertEqual(built.count(str(p1.resolve())), 1)
+
+
+# ── Dispatcher: discovery + read + write guard ─────────────────────────────
+
+
+class TestHandleProject(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.reg_file = self.base / "projects.json"
+        self.proj = _make_c3_project(self.base, "Target")
+        _write_registry(self.reg_file, [
+            {"name": "Target", "path": str(self.proj), "ide": "claude-code"},
+        ])
+        # Isolate BOTH the resolver's registry view (project_runtime) and the
+        # writer's registry (project_manager) onto the same temp file, so
+        # register/unregister never touch the real ~/.c3/projects.json.
+        from services import project_manager as pm
+        self._patches = [
+            mock.patch.object(pr, "_PROJECTS_FILE", self.reg_file),
+            mock.patch.object(pm, "_PROJECTS_FILE", self.reg_file),
+            mock.patch.object(pm, "_GLOBAL_C3_DIR", self.base),
+        ]
+        for p in self._patches:
+            p.start()
+        self.home = _StubSvc(str(self.base / "home"))
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self._tmp.cleanup()
+
+    def test_list_shows_registered(self):
+        finalize, _ = _captured_finalize()
+        resp = tool.handle_project("list", self.home, finalize)
+        self.assertIn("Target", resp)
+        self.assertIn("Registered C3 projects", resp)
+
+    def test_unknown_action_errors(self):
+        finalize, _ = _captured_finalize()
+        resp = tool.handle_project("frobnicate", self.home, finalize)
+        self.assertIn("Unknown action", resp)
+
+    def test_register_then_unregister(self):
+        finalize, _ = _captured_finalize()
+        new = _make_c3_project(self.base, "Fresh")
+        reg = tool.handle_project("register", self.home, finalize, project=str(new))
+        self.assertIn("Registered:", reg)
+        # It is now in the registry file.
+        data = json.loads(self.reg_file.read_text())
+        self.assertTrue(any(p["path"] == str(new.resolve()) for p in data["projects"]))
+
+    def test_read_op_proxies_to_handler(self):
+        fsvc = _StubSvc(str(self.proj))
+        finalize, _ = _captured_finalize()
+        with mock.patch.object(tool, "_runtime_for", return_value=fsvc), \
+             mock.patch("cli.tools.status.handle_status",
+                        return_value="STATUS-OK") as hs:
+            resp = tool.handle_project("status", self.home, finalize,
+                                       project="Target", view="health")
+        hs.assert_called_once()
+        self.assertIn("STATUS-OK", resp)
+        self.assertIn("[c3_project:Target]", resp)
+
+    def test_write_blocked_without_allow_write(self):
+        sentinel = mock.Mock(side_effect=AssertionError("should not build runtime"))
+        finalize, _ = _captured_finalize()
+        with mock.patch.object(tool, "_runtime_for", sentinel):
+            resp = tool.handle_project("edit", self.home, finalize,
+                                       project="Target", file_path="x.py",
+                                       old_string="a", new_string="b")
+        self.assertIn("[c3_project:blocked]", resp)
+        sentinel.assert_not_called()
+
+    def test_write_allowed_with_flag_and_audited(self):
+        fsvc = _StubSvc(str(self.proj))
+        finalize, _ = _captured_finalize()
+        with mock.patch.object(tool, "_runtime_for", return_value=fsvc), \
+             mock.patch("cli.tools.edit.handle_edit",
+                        return_value="EDITED") as he:
+            resp = tool.handle_project("edit", self.home, finalize,
+                                       project="Target", file_path="x.py",
+                                       old_string="a", new_string="b",
+                                       allow_write=True)
+        he.assert_called_once()
+        self.assertIn("EDITED", resp)
+        # The foreign project recorded the cross-project mutation.
+        self.assertTrue(
+            any(ev == "cross_project_write" for ev, _ in fsvc.activity_log.events)
+        )
+
+    def test_memory_write_subaction_blocked_without_flag(self):
+        sentinel = mock.Mock(side_effect=AssertionError("should not build runtime"))
+        finalize, _ = _captured_finalize()
+        with mock.patch.object(tool, "_runtime_for", sentinel):
+            resp = tool.handle_project("memory", self.home, finalize,
+                                       project="Target", mem_action="add",
+                                       fact="x", category="general")
+        self.assertIn("[c3_project:blocked]", resp)
+        sentinel.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds **`c3_project`** — a new MCP tool that lets C3 reach **outside the current workspace** to discover and operate on other c3-installed projects from a single session.

## What's included

- **`services/project_runtime.py`** — shared `ProjectRuntimeCache` (LRU, `.c3`-validated) that builds one `C3Runtime` per foreign project via the existing `build_runtime` seam; `resolve_project(name|path)`; and `scan_for_c3` / `discover_projects` (registry + bounded filesystem scan).
- **`cli/tools/project.py`** — the `c3_project` dispatcher:
  - **Discover**: `list`, `scan`, `info`, `register`, `unregister`
  - **Read**: `search`, `read`, `compress`, `status`, `memory`, `impact`, `edits`, `validate`, `filter`
  - **Write (guarded)**: `edit`, `shell`, memory `add/update/delete` — require `allow_write=true`; foreign mutations are logged to the target project's activity log + edit ledger.
- Registered in `cli/mcp_server.py` and added to `_C3_MCP_ALLOW`.
- Version bumped to **2.31.0** (`cli/c3.py` + `pyproject.toml`).
- Docs: README tool table, guide tool card + workflow row + tool counts, CHANGELOG, and the shared instruction template (CLAUDE/AGENTS/GEMINI/Copilot).

## Design decisions

- **Dedicated dispatcher** (vs. a `project=` param on every tool) keeps existing tool signatures untouched.
- **Reads run free, writes gated** behind `allow_write=true`, audited on the target project.
- **Discovery = registry + filesystem scan** so unregistered `.c3` projects surface too.

## Testing

- `tests/test_project_tool.py` — resolver, discovery, runtime-cache LRU/validation, dispatcher read-proxy + write-guard + audit.
- Targeted suite green (38 passed); full suite was 294 passed prior to unrelated parallel-session changes appearing in the working tree.

## Scope note

This branch contains **only** the cross-project feature. An unrelated, in-progress "Oracle Discovery API" change set (`oracle/*`) from a parallel session is present in the working tree and is intentionally **excluded** from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
