### PR TITLE
feat(2.32.0): Oracle Discovery API - external LLM tool surface (MCP + OpenAPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.0] - 2026-06-09
+
+Feature release. The **Oracle Discovery API** lets external LLMs — Claude Code /
+Claude Desktop and any function-calling model — point at a running Oracle and use
+C3's cross-project code & memory intelligence as tools, over **MCP (HTTP/SSE)** and
+a parallel **OpenAPI REST** surface that share one tool core. Read + safe-action
+tiers only (no code edits); Bearer-token auth; loopback-bound by default.
+
+### Added
+
+- `oracle/services/api_auth.py` — keyring-backed Bearer API key (`c3-oracle-api`),
+  with a `C3_ORACLE_API_KEY` env override for headless/CI; `secrets.compare_digest`
+  verification, plus `rotate`/`clear`/`peek`.
+- `oracle/services/tool_registry.py` — `TOOL_SPECS`, the single source of truth:
+  18 tools with JSON Schemas + capability tiers (`read`/`action`). `ToolRegistry`
+  does tier filtering, arg validation, dispatch, and OpenAPI 3.1 generation.
+- `oracle/services/tool_executor.py` — thin adapter routing the API through
+  `ChatEngine.run_tool`, so chat and the API share one dispatch path.
+- `oracle/mcp_oracle.py` — FastMCP HTTP/SSE server built from the registry, guarded
+  by a pure-ASGI Bearer middleware (streaming stays intact), served in a daemon thread.
+- Oracle REST endpoints under `/api/discovery/*`: `tools`, `call`, `tools/<name>`,
+  `call/stream` (SSE), `openapi.json`, `mcp-info` — all behind a `before_request`
+  Bearer guard.
+- `c3 oracle api {info,key,rotate,clear}` CLI — prints the token, REST/MCP URLs,
+  and a ready-to-paste Claude `.mcp.json` snippet.
+- Oracle config keys: `bind_host`, `api_enabled`, `api_require_auth`, `api_max_tier`,
+  `mcp_enabled`, `mcp_port`.
+- Tests: `test_oracle_api_auth.py`, `test_tool_registry.py`, `test_oracle_discovery_api.py`.
+
+### Changed
+
+- `ChatEngine` gained a public `run_tool()` entry point so the chat loop and the
+  Discovery API share one dispatch path.
+- The Oracle server now binds **`127.0.0.1`** by default (was `0.0.0.0`); set
+  `bind_host` in `~/.c3/oracle/config.json` to expose it on a network.
+
 ## [2.31.0] - 2026-06-09
 
 Feature release. C3 tools can now reach **outside the current workspace** to

--- a/cli/c3.py
+++ b/cli/c3.py
@@ -85,7 +85,7 @@ console = Console() if HAS_RICH else None
 # Config
 CONFIG_DIR = ".c3"
 CONFIG_FILE = ".c3/config.json"
-__version__ = "2.31.0"
+__version__ = "2.32.0"
 
 
 def _command_deps() -> CommandDeps:
@@ -5558,6 +5558,60 @@ def _bb_cmd_set_default(args, project_path: str) -> None:
     print(f"[OK] Default repo: {args.project}/{args.repo}")
 
 
+def cmd_oracle(args):
+    """Oracle Discovery API key + connection management."""
+    sub = getattr(args, "oracle_cmd", None)
+    if sub != "api":
+        print("Usage: c3 oracle api {info,key,rotate,clear}")
+        return
+
+    from oracle.config import load_config
+    from oracle.mcp_oracle import mcp_url
+    from oracle.services import api_auth
+
+    action = getattr(args, "action", "info") or "info"
+
+    if action == "rotate":
+        print("Rotated. New Discovery API key:")
+        print(f"  {api_auth.rotate()}")
+        return
+    if action == "clear":
+        removed = api_auth.clear()
+        print("Discovery API key cleared." if removed else "No stored Discovery API key to clear.")
+        return
+
+    key = api_auth.get_or_create_key()
+    if action == "key":
+        print(key)
+        return
+
+    cfg = load_config()
+    host = cfg.get("bind_host", "127.0.0.1")
+    disp_host = "127.0.0.1" if host in ("0.0.0.0", "") else host
+    rest_port = getattr(args, "port", None) or cfg.get("port", 3331)
+    mcp_port = getattr(args, "mcp_port", None) or cfg.get("mcp_port", 3332)
+    rest_base = f"http://{disp_host}:{rest_port}/api/discovery"
+    url = mcp_url(host, mcp_port)
+
+    print("[oracle:api]")
+    print(f"  REST base : {rest_base}")
+    print(f"  OpenAPI   : {rest_base}/openapi.json")
+    print(f"  MCP URL   : {url}")
+    print(f"  Auth      : Bearer {key}")
+    print()
+    print("  Claude .mcp.json entry:")
+    snippet = {
+        "mcpServers": {
+            "c3-oracle": {
+                "type": "http",
+                "url": url,
+                "headers": {"Authorization": f"Bearer {key}"},
+            }
+        }
+    }
+    print(json.dumps(snippet, indent=2))
+
+
 def cmd_projects(args):
     """Manage the global C3 project registry."""
     from services.project_manager import ProjectManager
@@ -6310,6 +6364,7 @@ def main():
         "projects": cmd_projects,
         "hub": cmd_hub,
         "bitbucket": cmd_bitbucket,
+        "oracle": cmd_oracle,
     }
 
     cmd_func = commands.get(args.command)

--- a/cli/commands/parser.py
+++ b/cli/commands/parser.py
@@ -322,4 +322,25 @@ def build_parser(version: str, parse_cli_ide_arg):
     bb_default.add_argument("--repo", required=True, help="Repository slug")
     bb_default.add_argument("project_path", nargs="?", default=".")
 
+    # ── Oracle Discovery API (v2.32.0) ──────────────────────────────────
+    p_oracle = subparsers.add_parser(
+        "oracle",
+        help="Oracle Discovery API key + connection management",
+    )
+    or_subs = p_oracle.add_subparsers(dest="oracle_cmd")
+    or_api = or_subs.add_parser(
+        "api",
+        help="Show connection info / manage the Discovery API key",
+    )
+    or_api.add_argument(
+        "action",
+        nargs="?",
+        default="info",
+        choices=["info", "key", "rotate", "clear"],
+        help="info (default): print REST+MCP URLs and a .mcp.json snippet; "
+             "key: print the token; rotate: replace it; clear: delete it",
+    )
+    or_api.add_argument("--port", type=int, default=None, help="Override REST port in printed info")
+    or_api.add_argument("--mcp-port", type=int, default=None, help="Override MCP port in printed info")
+
     return parser

--- a/guide/bitbucket.html
+++ b/guide/bitbucket.html
@@ -78,6 +78,7 @@
       <a href="workflow.html">Workflow</a>
       <a href="tools.html">Tools</a>
       <a href="bitbucket.html" class="active">Bitbucket</a>
+      <a href="oracle.html">Oracle</a>
     </nav>
     <span class="header-version">v2.30.0</span>
   </header>

--- a/guide/getting-started.html
+++ b/guide/getting-started.html
@@ -21,6 +21,7 @@
       <a href="workflow.html">Workflow</a>
       <a href="tools.html">Tools</a>
       <a href="bitbucket.html">Bitbucket</a>
+      <a href="oracle.html">Oracle</a>
     </nav>
     <span class="header-version">v2.x</span>
   </header>

--- a/guide/index.html
+++ b/guide/index.html
@@ -223,6 +223,7 @@
       <a href="workflow.html">Workflow</a>
       <a href="tools.html">Tools</a>
       <a href="bitbucket.html">Bitbucket</a>
+      <a href="oracle.html">Oracle</a>
     </nav>
     <span class="header-version">v2.x</span>
   </header>
@@ -260,6 +261,9 @@
       <div class="sidebar-label">Integrations</div>
       <a href="bitbucket.html" class="sidebar-link">
         <span class="icon">🪣</span> Bitbucket Data Center
+      </a>
+      <a href="oracle.html" class="sidebar-link">
+        <span class="icon">🔮</span> Oracle Discovery API
       </a>
     </div>
     <div class="sidebar-section">
@@ -311,6 +315,11 @@
         <span class="nav-card-icon">🪣</span>
         <div class="nav-card-title">Bitbucket Data Center</div>
         <div class="nav-card-desc">Self-hosted enterprise Bitbucket — PRs, branches, builds, repo admin (v2.30.0)</div>
+      </a>
+      <a href="oracle.html" class="nav-card">
+        <span class="nav-card-icon">🔮</span>
+        <div class="nav-card-title">Oracle Discovery API</div>
+        <div class="nav-card-desc">Let Claude or any LLM use C3's cross-project tools over MCP + OpenAPI (v2.32.0)</div>
       </a>
       <a href="tools.html#memory" class="nav-card">
         <span class="nav-card-icon">🧠</span>

--- a/guide/oracle.html
+++ b/guide/oracle.html
@@ -1,0 +1,384 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Oracle Discovery API — C3 Guide</title>
+  <link rel="stylesheet" href="shared.css">
+  <style>
+    .pill-row { display: flex; gap: 8px; flex-wrap: wrap; margin: 16px 0 28px; }
+    .pill {
+      padding: 4px 12px; border-radius: 999px; font-size: 11px;
+      font-family: var(--mono); border: 1px solid var(--border);
+      color: var(--text-dim); background: var(--bg-3);
+    }
+    .pill-accent { color: var(--cyan); border-color: var(--cyan); }
+    .pill-green  { color: var(--green); border-color: var(--green); }
+    .pill-purple { color: var(--purple); border-color: var(--purple); }
+    .pill-amber  { color: var(--amber); border-color: var(--amber); }
+
+    .action-table th, .action-table td { padding: 8px 12px; }
+    .action-table tr:hover { background: var(--bg-3); }
+    .action-table .grp-read   { color: var(--green); }
+    .action-table .grp-write  { color: var(--amber); }
+
+    .callout {
+      border-left: 3px solid var(--cyan);
+      background: var(--bg-2);
+      padding: 12px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin: 16px 0;
+    }
+    .callout-warn   { border-color: var(--amber); }
+    .callout-danger { border-color: var(--red);   }
+    .callout p:last-child { margin-bottom: 0; }
+    .callout strong { color: var(--text); }
+
+    .step-grid {
+      display: grid; gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      margin: 16px 0;
+    }
+    .step-card {
+      padding: 16px;
+      background: var(--bg-2);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+    .step-card .step-num {
+      display: inline-block; width: 22px; height: 22px;
+      background: var(--cyan); color: #000;
+      border-radius: 50%;
+      text-align: center; line-height: 22px;
+      font-size: 11px; font-weight: 700;
+      margin-right: 8px;
+    }
+    .step-card h4 { display: inline; font-size: 14px; }
+
+    .kv-table td { padding: 6px 12px; font-size: 13px; }
+    .kv-table td:first-child {
+      font-family: var(--mono); color: var(--text-dim); width: 200px; vertical-align: top;
+    }
+  </style>
+</head>
+<body>
+
+<div class="layout">
+  <!-- Header -->
+  <header class="header">
+    <a href="index.html" class="header-logo">
+      <span class="logo-badge">C3</span>
+      Claude Code Companion
+    </a>
+    <nav class="header-nav">
+      <a href="index.html">Home</a>
+      <a href="getting-started.html">Get Started</a>
+      <a href="workflow.html">Workflow</a>
+      <a href="tools.html">Tools</a>
+      <a href="bitbucket.html">Bitbucket</a>
+      <a href="oracle.html" class="active">Oracle</a>
+    </nav>
+    <span class="header-version">v2.32.0</span>
+  </header>
+
+  <!-- Sidebar -->
+  <aside class="sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-label">On this page</div>
+      <a href="#overview"        class="sidebar-link"><span class="icon">🔮</span> Overview</a>
+      <a href="#quick-start"     class="sidebar-link"><span class="icon">🚀</span> Quick start</a>
+      <a href="#connect-claude"  class="sidebar-link"><span class="icon">🤝</span> Connect Claude (MCP)</a>
+      <a href="#connect-openapi" class="sidebar-link"><span class="icon">🌐</span> Connect any LLM (REST)</a>
+      <a href="#endpoints"       class="sidebar-link"><span class="icon">📡</span> Endpoints</a>
+      <a href="#tools"           class="sidebar-link"><span class="icon">🧰</span> Tools &amp; tiers</a>
+      <a href="#auth"            class="sidebar-link"><span class="icon">🔐</span> Auth &amp; security</a>
+      <a href="#cli"             class="sidebar-link"><span class="icon">💻</span> CLI commands</a>
+      <a href="#config"          class="sidebar-link"><span class="icon">📂</span> Configuration</a>
+      <a href="#troubleshooting" class="sidebar-link"><span class="icon">🛠️</span> Troubleshooting</a>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-label">Related</div>
+      <a href="bitbucket.html"          class="sidebar-link">Bitbucket integration</a>
+      <a href="workflow.html"           class="sidebar-link">Standard workflow</a>
+    </div>
+  </aside>
+
+  <!-- Main -->
+  <main class="main">
+
+    <div class="page-hero">
+      <h1>Oracle Discovery API</h1>
+      <p>Point Claude — or any function-calling LLM — at a running Oracle and let it use C3's cross-project code &amp; memory intelligence as tools. Discover projects, search code and memory across all of them, traverse the memory graph, and surface insights, without ever opening the chat UI.</p>
+      <div class="pill-row">
+        <span class="pill pill-accent">v2.32.0</span>
+        <span class="pill pill-purple">External LLM tools</span>
+        <span class="pill pill-green">MCP + OpenAPI</span>
+        <span class="pill">Read &amp; safe-actions</span>
+        <span class="pill">Bearer + loopback</span>
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════ OVERVIEW ═══ -->
+    <section id="overview" class="tool-section">
+      <h2>Overview</h2>
+      <p>The Oracle normally runs the LLM relationship <em>inwards</em>: its own model (Ollama) calls C3 tools to analyze your projects. The Discovery API flips that — it exposes those same capabilities <strong>outwards</strong>, so an external LLM can use the Oracle as a discovery tool over your whole C3 estate.</p>
+
+      <div class="callout">
+        <p><strong>Two transports, one tool core.</strong> The exact same tool registry is served over both <strong>MCP</strong> (streamable HTTP/SSE — native for Claude Code / Claude Desktop) and an <strong>OpenAPI REST</strong> surface (for any function-calling LLM). They run on separate loopback ports because Flask is WSGI and the MCP transport is ASGI, but they dispatch through one definition of each tool — so the two surfaces can never drift apart.</p>
+      </div>
+
+      <h3>What you get</h3>
+      <table class="params-table">
+        <thead><tr><th>Surface</th><th>Where</th><th>Use it for</th></tr></thead>
+        <tbody>
+          <tr>
+            <td>MCP server</td>
+            <td><code>http://127.0.0.1:3332/mcp</code></td>
+            <td>Native tool discovery for Claude Code / Desktop and any MCP client</td>
+          </tr>
+          <tr>
+            <td>REST + OpenAPI</td>
+            <td><code>http://127.0.0.1:3331/api/discovery</code></td>
+            <td>Function-calling for any LLM (GPT, Gemini, custom agents)</td>
+          </tr>
+          <tr>
+            <td><code>c3 oracle api</code> CLI</td>
+            <td>Terminal</td>
+            <td>Get the token + a ready-to-paste <code>.mcp.json</code> snippet; rotate / clear the key</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout callout-warn">
+        <p><strong>Safe by construction.</strong> Only <em>read</em> and <em>safe-action</em> tools are exposed — there are <strong>no code-editing tools</strong> on this surface. Both servers bind <code>127.0.0.1</code> (loopback) by default and require a Bearer token.</p>
+      </div>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ QUICK START ═══ -->
+    <section id="quick-start" class="tool-section">
+      <h2>Quick start</h2>
+      <p>Start the Oracle, grab your token, and connect a client.</p>
+
+      <div class="step-grid">
+        <div class="step-card">
+          <span class="step-num">1</span><h4>Start the Oracle</h4>
+          <pre><code>python oracle/oracle_server.py \
+  --no-browser</code></pre>
+          <p style="font-size: 12px; color: var(--text-dim); margin: 8px 0 0;">Prints the REST + MCP URLs and ensures an API key exists. The MCP server starts in a background thread.</p>
+        </div>
+        <div class="step-card">
+          <span class="step-num">2</span><h4>Get the token</h4>
+          <pre><code>c3 oracle api info</code></pre>
+          <p style="font-size: 12px; color: var(--text-dim); margin: 8px 0 0;">Prints the Bearer token, both URLs, and a ready-to-paste Claude <code>.mcp.json</code> entry. Use <code>c3 oracle api key</code> for just the token.</p>
+        </div>
+        <div class="step-card">
+          <span class="step-num">3</span><h4>Connect</h4>
+          <pre><code><span class="com"># Claude → paste the snippet</span>
+<span class="com"># Any LLM → fetch openapi.json</span></code></pre>
+          <p style="font-size: 12px; color: var(--text-dim); margin: 8px 0 0;">See the two sections below for the MCP config and the OpenAPI flow.</p>
+        </div>
+      </div>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ CONNECT CLAUDE ═══ -->
+    <section id="connect-claude" class="tool-section">
+      <h2>Connect Claude (MCP)</h2>
+      <p>Add the entry from <code>c3 oracle api info</code> to your <code>.mcp.json</code> (project root) or Claude Desktop config:</p>
+      <pre><code>{
+  <span class="str">"mcpServers"</span>: {
+    <span class="str">"c3-oracle"</span>: {
+      <span class="str">"type"</span>: <span class="str">"http"</span>,
+      <span class="str">"url"</span>: <span class="str">"http://127.0.0.1:3332/mcp"</span>,
+      <span class="str">"headers"</span>: { <span class="str">"Authorization"</span>: <span class="str">"Bearer &lt;token&gt;"</span> }
+    }
+  }
+}</code></pre>
+      <p>Claude lists the <code>c3-oracle</code> tools (<code>list_projects</code>, <code>c3_search_cross</code>, <code>query_memory</code>, <code>read_graph</code>, …). Ask it to <em>"discover what C3 projects exist and search them for X"</em>.</p>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ CONNECT OPENAPI ═══ -->
+    <section id="connect-openapi" class="tool-section">
+      <h2>Connect any LLM (OpenAPI REST)</h2>
+      <p>Every tool is also a plain REST operation. Point a function-calling LLM at the spec, then call tools with the Bearer header.</p>
+      <pre><code><span class="com"># Discover the tools (OpenAPI 3.1)</span>
+curl -H <span class="str">"Authorization: Bearer &lt;token&gt;"</span> \
+     http://127.0.0.1:3331/api/discovery/openapi.json
+
+<span class="com"># Invoke a tool by name</span>
+curl -X POST \
+     -H <span class="str">"Authorization: Bearer &lt;token&gt;"</span> \
+     -H <span class="str">"Content-Type: application/json"</span> \
+     -d <span class="str">'{"tool":"list_projects","args":{}}'</span> \
+     http://127.0.0.1:3331/api/discovery/call
+
+<span class="com"># Or use the per-tool path (body = the tool's args)</span>
+curl -X POST \
+     -H <span class="str">"Authorization: Bearer &lt;token&gt;"</span> \
+     -H <span class="str">"Content-Type: application/json"</span> \
+     -d <span class="str">'{"query":"rate limiter","top_k":5}'</span> \
+     http://127.0.0.1:3331/api/discovery/tools/c3_search_cross</code></pre>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ ENDPOINTS ═══ -->
+    <section id="endpoints" class="tool-section">
+      <h2>REST endpoints</h2>
+      <p>All under <code>/api/discovery</code>; every request requires <code>Authorization: Bearer &lt;token&gt;</code>.</p>
+      <table class="params-table">
+        <thead><tr><th>Endpoint</th><th>Description</th></tr></thead>
+        <tbody>
+          <tr><td><code>GET /tools</code></td>                  <td>Available tools, each with a JSON Schema and capability tier</td></tr>
+          <tr><td><code>POST /call</code></td>                  <td>Invoke any tool: body <code>{"tool": name, "args": {…}}</code></td></tr>
+          <tr><td><code>POST /tools/&lt;name&gt;</code></td>     <td>Invoke a named tool with the request body as its arguments object</td></tr>
+          <tr><td><code>POST /call/stream</code></td>           <td>Same as <code>/call</code> but streams <code>start → result|error → [DONE]</code> as SSE</td></tr>
+          <tr><td><code>GET /openapi.json</code></td>           <td>OpenAPI 3.1 document — one operation per tool</td></tr>
+          <tr><td><code>GET /mcp-info</code></td>               <td>MCP URL + auth scheme for the streamable-HTTP transport</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ TOOLS ═══ -->
+    <section id="tools" class="tool-section">
+      <h2>Tools &amp; capability tiers</h2>
+      <p>The exposed set is capped by <code>api_max_tier</code> in <code>~/.c3/oracle/config.json</code> (<code>read</code> or <code>action</code>). Code-editing tools are never registered.</p>
+
+      <h3>Read tier — discovery</h3>
+      <table class="params-table action-table">
+        <thead><tr><th>Tool</th><th>Does</th></tr></thead>
+        <tbody>
+          <tr><td class="grp-read"><code>list_projects</code></td>   <td>All registered C3 projects with paths + fact counts</td></tr>
+          <tr><td class="grp-read"><code>search_facts</code></td>    <td>Search memory facts across ALL projects</td></tr>
+          <tr><td class="grp-read"><code>query_memory</code></td>    <td>Search/list facts within one project</td></tr>
+          <tr><td class="grp-read"><code>project_health</code></td>  <td>Memory health check for a project</td></tr>
+          <tr><td class="grp-read"><code>analyze_project</code></td> <td>LLM-powered analysis of a project's memory themes</td></tr>
+          <tr><td class="grp-read"><code>cross_insights</code></td>  <td>Cross-project insights</td></tr>
+          <tr><td class="grp-read"><code>read_graph</code></td>      <td>Memory-graph statistics for a project</td></tr>
+          <tr><td class="grp-read"><code>c3_search</code> / <code>c3_search_cross</code></td><td>Code-intelligence search (one project / all projects)</td></tr>
+          <tr><td class="grp-read"><code>c3_read</code></td>         <td>Read exact file content (symbols / line ranges)</td></tr>
+          <tr><td class="grp-read"><code>c3_compress</code></td>     <td>Token-efficient structural file map</td></tr>
+          <tr><td class="grp-read"><code>c3_validate</code></td>     <td>Syntax/type validation on a file</td></tr>
+          <tr><td class="grp-read"><code>c3_status</code></td>       <td>Project health / budget / sessions overview</td></tr>
+          <tr><td class="grp-read"><code>c3_memory_query</code></td> <td>Read-only memory query (recall/list/score/graph/trends)</td></tr>
+          <tr><td class="grp-read"><code>c3_edits</code> / <code>c3_edits_cross</code></td><td>Query the edit ledger (one / all projects)</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Action tier — safe writes (no code edits)</h3>
+      <table class="params-table action-table">
+        <thead><tr><th>Tool</th><th>Does</th></tr></thead>
+        <tbody>
+          <tr><td class="grp-write"><code>suggest_action</code></td><td>Create a <strong>pending</strong> memory suggestion a human approves (not a direct write)</td></tr>
+          <tr><td class="grp-write"><code>delegate_task</code></td> <td>Run a configured Oracle agent and return its result</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ AUTH ═══ -->
+    <section id="auth" class="tool-section">
+      <h2>Authentication &amp; security</h2>
+      <p>A single Bearer token guards both transports. The REST surface checks it in a Flask <code>before_request</code> hook; the MCP transport checks it in a pure-ASGI middleware (so streaming responses pass through intact).</p>
+
+      <h3>Where the token lives</h3>
+      <table class="kv-table">
+        <tr>
+          <td>OS keyring</td>
+          <td>Token text, under service <code>c3-oracle-api</code>. Backed by <strong>Windows Credential Manager</strong>, <strong>macOS Keychain</strong>, or <strong>Linux Secret Service</strong>.</td>
+        </tr>
+        <tr>
+          <td><code>C3_ORACLE_API_KEY</code></td>
+          <td>Environment override for headless / CI / containers where no keyring backend exists. When set, it wins and is <strong>never</strong> persisted to the keyring.</td>
+        </tr>
+      </table>
+
+      <div class="callout callout-warn">
+        <p><strong>Exposing on a network.</strong> The default bind is <code>127.0.0.1</code>. To let a remote LLM service reach the Oracle, set <code>bind_host</code> to <code>0.0.0.0</code> in <code>~/.c3/oracle/config.json</code> — and put it behind TLS + a firewall yourself. The token alone is not a substitute for transport security.</p>
+      </div>
+
+      <p>Rotate or revoke at any time with <code>c3 oracle api rotate</code> / <code>c3 oracle api clear</code>.</p>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ CLI ═══ -->
+    <section id="cli" class="tool-section">
+      <h2>CLI commands</h2>
+      <table class="params-table">
+        <thead><tr><th>Command</th><th>Description</th></tr></thead>
+        <tbody>
+          <tr><td><code>c3 oracle api info</code></td>   <td>Print REST + MCP URLs, the token, and a ready-to-paste <code>.mcp.json</code> snippet</td></tr>
+          <tr><td><code>c3 oracle api key</code></td>    <td>Print just the token (generating one if needed)</td></tr>
+          <tr><td><code>c3 oracle api rotate</code></td> <td>Replace the token with a fresh one</td></tr>
+          <tr><td><code>c3 oracle api clear</code></td>  <td>Delete the stored token from the keyring</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ CONFIGURATION ═══ -->
+    <section id="config" class="tool-section">
+      <h2><code>~/.c3/oracle/config.json</code> keys</h2>
+      <table class="kv-table">
+        <tr><td><code>bind_host</code></td>        <td>Interface to bind. Default <code>127.0.0.1</code>. Use <code>0.0.0.0</code> to expose on a network (add TLS/firewall).</td></tr>
+        <tr><td><code>api_enabled</code></td>      <td>Serve the <code>/api/discovery/*</code> REST surface. Default <code>true</code>.</td></tr>
+        <tr><td><code>api_require_auth</code></td> <td>Require the Bearer token. Default <code>true</code>.</td></tr>
+        <tr><td><code>api_max_tier</code></td>     <td>Cap exposed tools: <code>read</code> (discovery only) or <code>action</code> (adds <code>suggest_action</code>, <code>delegate_task</code>). Default <code>action</code>.</td></tr>
+        <tr><td><code>mcp_enabled</code></td>      <td>Start the MCP HTTP/SSE server. Default <code>true</code>.</td></tr>
+        <tr><td><code>mcp_port</code></td>         <td>MCP transport port. Default <code>3332</code>.</td></tr>
+      </table>
+    </section>
+
+    <hr class="divider">
+
+    <!-- ═══════════════════════════════════════ TROUBLESHOOTING ═══ -->
+    <section id="troubleshooting" class="tool-section">
+      <h2>Troubleshooting</h2>
+      <table class="params-table">
+        <thead><tr><th>Symptom</th><th>Cause &amp; fix</th></tr></thead>
+        <tbody>
+          <tr>
+            <td><code>401 unauthorized</code></td>
+            <td>Missing or wrong token. Get the current one with <code>c3 oracle api key</code> and send it as <code>Authorization: Bearer &lt;token&gt;</code>.</td>
+          </tr>
+          <tr>
+            <td>Claude doesn't list the tools</td>
+            <td>Confirm the Oracle is running and <code>mcp_enabled</code> is <code>true</code>; check the URL is <code>http://127.0.0.1:3332/mcp</code> and the <code>Authorization</code> header is present in <code>.mcp.json</code>.</td>
+          </tr>
+          <tr>
+            <td>Tool not found in the catalog</td>
+            <td>It may be above your <code>api_max_tier</code> (e.g. <code>suggest_action</code> needs <code>action</code>), or it is a code-editing tool — those are never exposed.</td>
+          </tr>
+          <tr>
+            <td>Need a token without a keyring</td>
+            <td>Set <code>C3_ORACLE_API_KEY</code> in the environment (CI / containers). It overrides the keyring and is not persisted.</td>
+          </tr>
+          <tr>
+            <td><code>The 'keyring' package is required</code></td>
+            <td><code>pip install keyring</code> — a C3 dependency that may be missing if you upgraded without re-installing.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <hr class="divider">
+
+    <p style="color: var(--text-dim); font-size: 12px; text-align: center; margin: 24px 0 48px;">
+      Full endpoint and schema details live in <code>oracle-guide/api-reference.md</code> and <code>oracle-guide/discovery-api.md</code>.
+    </p>
+
+  </main>
+</div>
+
+</body>
+</html>

--- a/guide/tools.html
+++ b/guide/tools.html
@@ -80,6 +80,7 @@
       <a href="workflow.html">Workflow</a>
       <a href="tools.html" class="active">Tools</a>
       <a href="bitbucket.html">Bitbucket</a>
+      <a href="oracle.html">Oracle</a>
     </nav>
     <span class="header-version">v2.x</span>
   </header>

--- a/guide/workflow.html
+++ b/guide/workflow.html
@@ -223,6 +223,7 @@
       <a href="workflow.html" class="active">Workflow</a>
       <a href="tools.html">Tools</a>
       <a href="bitbucket.html">Bitbucket</a>
+      <a href="oracle.html">Oracle</a>
     </nav>
     <span class="header-version">v2.x</span>
   </header>

--- a/oracle-guide/README.md
+++ b/oracle-guide/README.md
@@ -23,6 +23,7 @@ Open `http://localhost:3331` in your browser.
 - **Ollama cloud**: Uses `https://ollama.com` with Bearer token auth by default. Can also target a local Ollama instance.
 - **Hub-aware**: Discovers projects through the C3 hub API or falls back to reading `~/.c3/projects.json` directly.
 - **Read + suggest-write**: Oracle reads project memory freely. Writes to project `.c3/facts/` require explicit user approval in the UI.
+- **Discovery API (v2.32.0)**: External LLMs (Claude Code/Desktop or any function-calling model) can use Oracle's tools over MCP (`:3332/mcp`) and OpenAPI REST (`/api/discovery`) — Bearer-auth'd, loopback-bound, read + safe-action tiers only. See [Discovery API](discovery-api.md).
 - **Cross-project memory**: Maintains a global insight store (`~/.c3/oracle/cross_memory.json`) linking patterns, risks, and opportunities across projects.
 - **Background review**: A daemon thread periodically scans projects for changes, runs health checks, and generates consolidation suggestions.
 - **Notifications & activity**: The UI shows toast notifications for all actions and a global busy indicator when Oracle is processing.
@@ -33,6 +34,7 @@ Open `http://localhost:3331` in your browser.
 |-------|-------------|
 | [Architecture](architecture.md) | System design, data flow, folder structure, service diagram |
 | [API Reference](api-reference.md) | All REST endpoints with request/response examples |
+| [Discovery API](discovery-api.md) | Expose C3's tools to external LLMs over MCP + OpenAPI (v2.32.0) |
 | [Configuration](configuration.md) | Config options, authentication, model selection |
 | [Changelog](changelog.md) | Version history and changes |
 

--- a/oracle-guide/api-reference.md
+++ b/oracle-guide/api-reference.md
@@ -334,6 +334,87 @@ Test generation with the current model. Sends a simple prompt and returns the re
 
 ---
 
+## Discovery API (external LLM tool surface)
+
+> Added in v2.32.0. Lets Claude or any function-calling LLM use C3's cross-project
+> code & memory intelligence as tools. **Bearer-token auth required**; the Oracle
+> binds `127.0.0.1` by default.
+
+Get your token + connection snippet with `c3 oracle api info` (or `c3 oracle api key`
+for just the token). All `/api/discovery/*` requests require
+`Authorization: Bearer <token>`.
+
+### `GET /api/discovery/tools`
+
+Returns the available tools, each with a JSON Schema and capability tier.
+
+```json
+{ "tier": "action",
+  "tools": [ { "name": "c3_search_cross", "tier": "read",
+               "description": "...", "parameters": { "type": "object" } } ] }
+```
+
+### `POST /api/discovery/call`
+
+Invoke any tool by name.
+
+```json
+// Request
+{ "tool": "list_projects", "args": {} }
+```
+
+### `POST /api/discovery/tools/<name>`
+
+Invoke a named tool with the request body as its arguments object (one operation
+per tool — matches the generated OpenAPI paths).
+
+```json
+// POST /api/discovery/tools/c3_search_cross
+{ "query": "rate limiter", "top_k": 5 }
+```
+
+### `POST /api/discovery/call/stream`
+
+Same as `/call`, but streams `start` → `result`|`error` → `[DONE]` as SSE
+(`text/event-stream`).
+
+### `GET /api/discovery/openapi.json`
+
+OpenAPI 3.1 document describing every available tool as a
+`POST /api/discovery/tools/{name}` operation. Point a generic function-calling LLM
+at this URL to auto-register the tools.
+
+### `GET /api/discovery/mcp-info`
+
+Connection details for the MCP transport.
+
+```json
+{ "enabled": true, "transport": "http",
+  "url": "http://127.0.0.1:3332/mcp", "auth": "bearer",
+  "rest_base": "http://127.0.0.1:3331/api/discovery" }
+```
+
+### Capability tiers
+
+- **read** — discovery only: `list_projects`, `search_facts`, `query_memory`,
+  `project_health`, `analyze_project`, `cross_insights`, `read_graph`, `c3_search`,
+  `c3_search_cross`, `c3_read`, `c3_compress`, `c3_validate`, `c3_status`,
+  `c3_memory_query`, `c3_edits`, `c3_edits_cross`.
+- **action** — adds safe, non-code-edit writes: `suggest_action` (creates a
+  *pending* suggestion for human approval) and `delegate_task`.
+- Code-editing tools are **never** exposed. Cap the tier via `api_max_tier`
+  (`read` | `action`) in `~/.c3/oracle/config.json`.
+
+---
+
+## MCP transport
+
+The same tools are served over MCP streamable-HTTP at `http://127.0.0.1:3332/mcp`
+(port = `mcp_port`). Every request requires `Authorization: Bearer <token>`. See
+[discovery-api.md](discovery-api.md) for a Claude `.mcp.json` example.
+
+---
+
 ## Error Responses
 
 All endpoints return errors as JSON with appropriate HTTP status codes:

--- a/oracle-guide/discovery-api.md
+++ b/oracle-guide/discovery-api.md
@@ -1,0 +1,103 @@
+# Oracle Discovery API — connect an external LLM
+
+The Oracle can expose C3's cross-project code & memory intelligence as **tools** for
+an external LLM. Point Claude (or any function-calling model) at a running Oracle and
+it can discover your projects, search code and memory across all of them, traverse the
+memory graph, and surface insights — without ever touching the chat UI.
+
+Two transports share one tool core:
+
+- **MCP** (streamable HTTP/SSE) at `http://127.0.0.1:3332/mcp` — native for Claude
+  Code / Claude Desktop / any MCP client.
+- **OpenAPI REST** at `http://127.0.0.1:3331/api/discovery` — for any LLM with
+  function-calling.
+
+> Security: both bind to `127.0.0.1` (loopback) by default and require a Bearer token.
+> Only **read** and **safe-action** tools are exposed — no code-editing tools.
+
+---
+
+## 1. Start the Oracle
+
+```bash
+python oracle/oracle_server.py --no-browser
+```
+
+On startup it prints both URLs and ensures an API key exists.
+
+## 2. Get your token + connection info
+
+```bash
+c3 oracle api info        # REST + MCP URLs and a ready-to-paste .mcp.json snippet
+c3 oracle api key         # just the token
+c3 oracle api rotate      # replace the token
+c3 oracle api clear       # delete the stored token
+```
+
+The token lives in your OS keyring (Windows Credential Manager / macOS Keychain /
+Linux Secret Service). For headless/CI, set `C3_ORACLE_API_KEY` instead — it
+overrides the keyring and is never persisted.
+
+## 3a. Connect Claude (MCP)
+
+Add this to your `.mcp.json` (project root) or Claude Desktop config:
+
+```json
+{
+  "mcpServers": {
+    "c3-oracle": {
+      "type": "http",
+      "url": "http://127.0.0.1:3332/mcp",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```
+
+Claude will list the `c3-oracle` tools (e.g. `list_projects`, `c3_search_cross`,
+`query_memory`, `read_graph`). Start a session and ask it to "discover what projects
+exist and search them for X".
+
+## 3b. Connect any function-calling LLM (OpenAPI)
+
+Fetch the spec and register the tools, then call them with the Bearer header:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+     http://127.0.0.1:3331/api/discovery/openapi.json
+
+curl -X POST -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
+     -d '{"tool":"list_projects","args":{}}' \
+     http://127.0.0.1:3331/api/discovery/call
+```
+
+Each tool is also a discrete operation at `POST /api/discovery/tools/<name>` whose
+request body is the tool's arguments object.
+
+---
+
+## Configuration
+
+Set in `~/.c3/oracle/config.json`:
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `bind_host` | `127.0.0.1` | Interface to bind (use `0.0.0.0` to expose on a network — then add TLS/firewalling). |
+| `api_enabled` | `true` | Serve the REST surface. |
+| `api_require_auth` | `true` | Require the Bearer token. |
+| `api_max_tier` | `action` | Cap exposed tools: `read` (discovery only) or `action` (adds `suggest_action`, `delegate_task`). |
+| `mcp_enabled` | `true` | Start the MCP HTTP/SSE server. |
+| `mcp_port` | `3332` | MCP transport port. |
+
+## Tools at a glance
+
+**Discovery (read):** `list_projects`, `search_facts`, `query_memory`,
+`project_health`, `analyze_project`, `cross_insights`, `read_graph`, `c3_search`,
+`c3_search_cross`, `c3_read`, `c3_compress`, `c3_validate`, `c3_status`,
+`c3_memory_query`, `c3_edits`, `c3_edits_cross`.
+
+**Safe actions:** `suggest_action` (creates a *pending* memory suggestion a human
+approves), `delegate_task` (runs a configured Oracle agent).
+
+See [api-reference.md](api-reference.md#discovery-api-external-llm-tool-surface) for
+full endpoint and schema details.

--- a/oracle/config.py
+++ b/oracle/config.py
@@ -9,6 +9,13 @@ CONFIG_FILE = ORACLE_DIR / "config.json"
 
 DEFAULTS = {
     "port": 3331,
+    # ── Discovery API (external LLM tool surface, v2.32.0) ──
+    "bind_host": "127.0.0.1",       # loopback only by default (was 0.0.0.0)
+    "api_enabled": True,            # expose /api/discovery/* REST surface
+    "api_require_auth": True,       # require Bearer token on /api/discovery/*
+    "api_max_tier": "action",       # cap exposed tools: "read" | "action"
+    "mcp_enabled": True,            # start FastMCP HTTP/SSE discovery server
+    "mcp_port": 3332,               # discovery MCP transport port (loopback)
     "ollama_base_url": "https://ollama.com",
     "ollama_api_key": "",
     "model": "gemma4:31b-cloud",

--- a/oracle/mcp_oracle.py
+++ b/oracle/mcp_oracle.py
@@ -1,0 +1,146 @@
+"""FastMCP HTTP/SSE server exposing the Oracle Discovery tools to external LLMs.
+
+Serves the same :class:`~oracle.services.tool_registry.ToolRegistry` as the REST
+surface, over MCP streamable-HTTP at ``http://<host>:<mcp_port>/mcp``, guarded by
+the shared API-key (Bearer) auth. Runs in a daemon thread alongside the Oracle
+Flask app — uvicorn with signal handlers disabled, since those only install on
+the main thread.
+
+All heavy imports (fastmcp, starlette, uvicorn) are lazy so importing this module
+never hard-requires them; the Oracle degrades to REST-only if they are missing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from typing import Any
+
+from oracle.services import api_auth
+
+logger = logging.getLogger("oracle.mcp")
+
+_INSTRUCTIONS = (
+    "C3 Oracle Discovery — cross-project code & memory intelligence as tools. "
+    "Start with list_projects to see available projects, then use c3_search_cross "
+    "or search_facts to discover across all of them, or the per-project tools "
+    "(c3_search, c3_read, c3_compress, query_memory, read_graph) with a project_path. "
+    "suggest_action creates a PENDING suggestion for human approval; delegate_task runs "
+    "a configured Oracle agent. No code-editing tools are exposed."
+)
+
+
+def _build_registry_tool_cls():
+    """Build the RegistryTool subclass (lazy — needs fastmcp + pydantic)."""
+    from fastmcp.tools.tool import Tool, ToolResult
+    from pydantic import PrivateAttr
+
+    class RegistryTool(Tool):
+        """A FastMCP tool whose schema + dispatch come from the ToolRegistry."""
+
+        _registry: Any = PrivateAttr(default=None)
+
+        async def run(self, arguments: dict) -> ToolResult:  # type: ignore[override]
+            try:
+                result = self._registry.call_tool(self.name, arguments or {})
+            except Exception as e:  # defensive: never surface a raw 500
+                result = {"error": f"tool '{self.name}' failed: {e}"}
+            return ToolResult(content=json.dumps(result, default=str))
+
+    return RegistryTool
+
+
+def build_mcp(registry, version: str = ""):
+    """Create a FastMCP server with one MCP tool per available registry spec."""
+    from fastmcp import FastMCP
+
+    name = f"C3 Oracle Discovery v{version}" if version else "C3 Oracle Discovery"
+    mcp = FastMCP(name, instructions=_INSTRUCTIONS)
+    registry_tool_cls = _build_registry_tool_cls()
+    for spec in registry.list_tools():
+        tool = registry_tool_cls(
+            name=spec["name"],
+            description=spec["description"],
+            parameters=spec["parameters"],
+        )
+        tool._registry = registry
+        mcp.add_tool(tool)
+    return mcp
+
+
+class _BearerAuthMiddleware:
+    """Pure-ASGI Bearer-token gate.
+
+    Implemented at the ASGI layer (not Starlette's ``BaseHTTPMiddleware``) so it
+    never buffers responses — MCP streamable-HTTP / SSE responses stream through
+    intact. Rejects requests whose ``Authorization`` header fails ``api_auth.verify``.
+    """
+
+    def __init__(self, app, require_auth: bool = True):
+        self.app = app
+        self.require_auth = require_auth
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") == "http" and self.require_auth:
+            headers = dict(scope.get("headers") or [])
+            auth = headers.get(b"authorization", b"").decode("latin-1")
+            if not api_auth.verify(api_auth.extract_bearer(auth)):
+                body = b'{"error": "unauthorized"}'
+                await send({
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [(b"content-type", b"application/json"),
+                                (b"content-length", str(len(body)).encode())],
+                })
+                await send({"type": "http.response.body", "body": body})
+                return
+        await self.app(scope, receive, send)
+
+
+def build_app(registry, version: str = "", require_auth: bool = True, path: str = "/mcp"):
+    """Build the Starlette ASGI app for the MCP server (auth middleware attached)."""
+    mcp = build_mcp(registry, version)
+    app = mcp.http_app(path=path)
+    if require_auth:
+        app.add_middleware(_BearerAuthMiddleware)
+    return app
+
+
+def serve_mcp(registry, host: str = "127.0.0.1", port: int = 3332,
+              version: str = "", require_auth: bool = True, path: str = "/mcp") -> None:
+    """Blocking: serve the MCP app with uvicorn. Safe to run off the main thread."""
+    import uvicorn
+
+    app = build_app(registry, version=version, require_auth=require_auth, path=path)
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning", access_log=False)
+    server = uvicorn.Server(config)
+    # uvicorn only installs signal handlers on the main thread; disable so this
+    # can run inside a daemon thread under the Flask server.
+    server.install_signal_handlers = lambda: None
+    asyncio.run(server.serve())
+
+
+def start_mcp_thread(registry, host: str = "127.0.0.1", port: int = 3332,
+                     version: str = "", require_auth: bool = True,
+                     path: str = "/mcp") -> threading.Thread:
+    """Start :func:`serve_mcp` in a daemon thread and return the thread."""
+
+    def _run():
+        try:
+            serve_mcp(registry, host=host, port=port, version=version,
+                      require_auth=require_auth, path=path)
+        except Exception:
+            logger.exception("Oracle MCP server crashed")
+
+    thread = threading.Thread(target=_run, daemon=True, name="oracle-mcp")
+    thread.start()
+    logger.info("Oracle MCP server thread started on http://%s:%s%s", host, port, path)
+    return thread
+
+
+def mcp_url(host: str, port: int, path: str = "/mcp") -> str:
+    """Loopback-friendly URL for clients (collapses 0.0.0.0 to 127.0.0.1)."""
+    display_host = "127.0.0.1" if host in ("0.0.0.0", "") else host
+    return f"http://{display_host}:{port}{path}"

--- a/oracle/oracle_server.py
+++ b/oracle/oracle_server.py
@@ -19,6 +19,9 @@ if str(_PROJECT_ROOT) not in sys.path:
 from flask import Flask, Response, jsonify, request, send_from_directory  # noqa: E402
 
 from oracle.config import ORACLE_DIR, load_config, save_config  # noqa: E402
+from oracle.mcp_oracle import mcp_url, start_mcp_thread  # noqa: E402
+from oracle.services.api_auth import extract_bearer  # noqa: E402
+from oracle.services.api_auth import verify as verify_api_key  # noqa: E402
 from oracle.services.c3_bridge import C3Bridge  # noqa: E402
 from oracle.services.chat_engine import ChatEngine  # noqa: E402
 from oracle.services.chat_store import ChatStore  # noqa: E402
@@ -31,6 +34,8 @@ from oracle.services.memory_writer import MemoryWriter  # noqa: E402
 from oracle.services.ollama_bridge import OllamaBridge  # noqa: E402
 from oracle.services.project_scanner import ProjectScanner  # noqa: E402
 from oracle.services.review_agent import ReviewAgent  # noqa: E402
+from oracle.services.tool_executor import ToolExecutor  # noqa: E402
+from oracle.services.tool_registry import ToolRegistry, _c3_version  # noqa: E402
 
 # ── App ───────────────────────────────────────────────────
 app = Flask(__name__)
@@ -50,10 +55,11 @@ _chat_store: ChatStore | None = None
 _chat_engine: ChatEngine | None = None
 _c3_bridge: C3Bridge | None = None
 _federated: FederatedGraph | None = None
+_tool_registry: ToolRegistry | None = None
 
 
 def _init_services():
-    global _cfg, _bridge, _scanner, _reader, _checker, _writer, _cross_memory, _engine, _agent, _model_verified, _chat_store, _chat_engine, _c3_bridge, _federated
+    global _cfg, _bridge, _scanner, _reader, _checker, _writer, _cross_memory, _engine, _agent, _model_verified, _chat_store, _chat_engine, _c3_bridge, _federated, _tool_registry
     _cfg = load_config()
     _bridge = OllamaBridge(
         base_url=_cfg.get("ollama_base_url", "https://ollama.com"),
@@ -101,6 +107,10 @@ def _init_services():
         store=_chat_store,
         c3_bridge=_c3_bridge,
     )
+    _tool_registry = ToolRegistry(
+        ToolExecutor(_chat_engine),
+        max_tier=_cfg.get("api_max_tier", "action"),
+    )
     atexit.register(lambda: _c3_bridge.shutdown() if _c3_bridge else None)
 
 
@@ -108,9 +118,27 @@ def _init_services():
 @app.after_request
 def _cors(resp):
     resp.headers["Access-Control-Allow-Origin"] = "*"
-    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
     resp.headers["Access-Control-Allow-Methods"] = "GET,POST,PUT,DELETE,OPTIONS"
     return resp
+
+
+# ── Discovery API auth guard ──────────────────────────────
+@app.before_request
+def _discovery_auth_guard():
+    """Bearer-token gate for the external Discovery API (``/api/discovery/*``)."""
+    path = request.path or ""
+    if not path.startswith("/api/discovery"):
+        return None
+    if request.method == "OPTIONS":
+        return None  # allow CORS preflight
+    if not _cfg.get("api_enabled", True):
+        return jsonify({"error": "discovery API disabled"}), 404
+    if _cfg.get("api_require_auth", True):
+        token = extract_bearer(request.headers.get("Authorization"))
+        if not verify_api_key(token):
+            return jsonify({"error": "unauthorized"}), 401
+    return None
 
 
 # ── Static ────────────────────────────────────────────────
@@ -570,6 +598,92 @@ def api_chat_conversation_state(conv_id):
     return jsonify({"state": _chat_store.get_state(conv_id)})
 
 
+# ── Discovery API (external LLM tool surface) ─────────────
+@app.route("/api/discovery/tools", methods=["GET"])
+def api_discovery_tools():
+    """List available discovery tools with their JSON schemas and capability tier."""
+    if not _tool_registry:
+        return jsonify({"error": "not initialized"}), 500
+    return jsonify({"tools": _tool_registry.list_tools(), "tier": _tool_registry.max_tier})
+
+
+@app.route("/api/discovery/call", methods=["POST"])
+def api_discovery_call():
+    """Invoke any discovery tool: body {"tool": name, "args": {...}}."""
+    if not _tool_registry:
+        return jsonify({"error": "not initialized"}), 500
+    data = request.get_json(silent=True) or {}
+    name = (data.get("tool") or "").strip()
+    if not name:
+        return jsonify({"error": "missing 'tool'"}), 400
+    args = data.get("args") or {}
+    if not isinstance(args, dict):
+        return jsonify({"error": "'args' must be an object"}), 400
+    return jsonify(_tool_registry.call_tool(name, args))
+
+
+@app.route("/api/discovery/tools/<name>", methods=["POST"])
+def api_discovery_call_named(name):
+    """Invoke a named tool with the request body as its arguments object."""
+    if not _tool_registry:
+        return jsonify({"error": "not initialized"}), 500
+    args = request.get_json(silent=True) or {}
+    if not isinstance(args, dict):
+        return jsonify({"error": "request body must be a JSON object of arguments"}), 400
+    return jsonify(_tool_registry.call_tool(name, args))
+
+
+@app.route("/api/discovery/call/stream", methods=["POST"])
+def api_discovery_call_stream():
+    """Invoke a tool and stream {start, result|error, [DONE]} as SSE."""
+    if not _tool_registry:
+        return jsonify({"error": "not initialized"}), 500
+    data = request.get_json(silent=True) or {}
+    name = (data.get("tool") or "").strip()
+    args = data.get("args") or {}
+    if not name:
+        return jsonify({"error": "missing 'tool'"}), 400
+    if not isinstance(args, dict):
+        return jsonify({"error": "'args' must be an object"}), 400
+
+    def generate():
+        yield f"data: {json.dumps({'type': 'start', 'tool': name})}\n\n"
+        try:
+            result = _tool_registry.call_tool(name, args)
+            yield f"data: {json.dumps({'type': 'result', 'tool': name, 'result': result}, default=str)}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'type': 'error', 'error': str(e)})}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return Response(
+        generate(),
+        mimetype="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no", "Connection": "keep-alive"},
+    )
+
+
+@app.route("/api/discovery/openapi.json", methods=["GET"])
+def api_discovery_openapi():
+    """OpenAPI 3.1 document describing every available discovery tool."""
+    if not _tool_registry:
+        return jsonify({"error": "not initialized"}), 500
+    return jsonify(_tool_registry.openapi_spec(request.host_url))
+
+
+@app.route("/api/discovery/mcp-info", methods=["GET"])
+def api_discovery_mcp_info():
+    """Connection details for the MCP transport (URL + auth scheme)."""
+    host = _cfg.get("bind_host", "127.0.0.1")
+    port = int(_cfg.get("mcp_port", 3332))
+    return jsonify({
+        "enabled": bool(_cfg.get("mcp_enabled", True)),
+        "transport": "http",
+        "url": mcp_url(host, port),
+        "auth": "bearer",
+        "rest_base": request.host_url.rstrip("/") + "/api/discovery",
+    })
+
+
 # ── Error handlers ────────────────────────────────────────
 @app.errorhandler(404)
 def not_found(e):
@@ -647,10 +761,29 @@ def run_oracle(port: int = None, open_browser: bool = None):
         _agent.start()
         atexit.register(_agent.stop)
 
+    # Start the discovery MCP server on its own loopback port if enabled.
+    if cfg.get("mcp_enabled", True) and _tool_registry is not None:
+        try:
+            from oracle.services.api_auth import get_or_create_key
+
+            get_or_create_key()  # ensure a Bearer key exists for clients
+            mcp_host = cfg.get("bind_host", "127.0.0.1")
+            mcp_p = int(cfg.get("mcp_port", 3332))
+            start_mcp_thread(
+                _tool_registry,
+                host=mcp_host,
+                port=mcp_p,
+                version=_c3_version(),
+                require_auth=cfg.get("api_require_auth", True),
+            )
+            print(f"Oracle Discovery MCP  →  {mcp_url(mcp_host, mcp_p)}  (auth: bearer)")
+        except Exception as e:
+            logging.getLogger("oracle").warning("MCP server not started: %s", e)
+
     if open_browser:
         threading.Timer(0.8, lambda: webbrowser.open(url)).start()
 
-    app.run(host="0.0.0.0", port=actual_port, debug=False, use_reloader=False)
+    app.run(host=cfg.get("bind_host", "127.0.0.1"), port=actual_port, debug=False, use_reloader=False)
 
 
 if __name__ == "__main__":

--- a/oracle/services/api_auth.py
+++ b/oracle/services/api_auth.py
@@ -1,0 +1,120 @@
+"""API-key authentication for the Oracle Discovery API.
+
+Stores a single Bearer token in the OS keyring (Windows Credential Manager /
+macOS Keychain / Linux Secret Service), mirroring ``services/bitbucket_credentials.py``.
+
+An optional ``C3_ORACLE_API_KEY`` environment variable overrides the keyring — useful
+for headless/CI/containers where no keyring backend exists. Env-provided keys are
+never written back to the keyring.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+
+KEYRING_SERVICE = "c3-oracle-api"
+KEYRING_ACCOUNT = "discovery-api"
+ENV_OVERRIDE = "C3_ORACLE_API_KEY"
+
+
+class ApiAuthError(RuntimeError):
+    """Raised when the keyring backend is unavailable or a write fails."""
+
+
+def _keyring_module():
+    """Import keyring lazily so import-time failures don't crash unrelated code."""
+    try:
+        import keyring  # type: ignore[import-untyped]
+
+        return keyring
+    except ImportError as exc:  # pragma: no cover — only on broken installs
+        raise ApiAuthError(
+            "The 'keyring' package is required for Oracle API key storage. "
+            "Run: pip install keyring"
+        ) from exc
+
+
+def _env_key() -> str | None:
+    val = os.environ.get(ENV_OVERRIDE, "").strip()
+    return val or None
+
+
+def _generate() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _store(key: str) -> None:
+    # Keys supplied via the environment are authoritative and not persisted.
+    if _env_key():
+        return
+    try:
+        _keyring_module().set_password(KEYRING_SERVICE, KEYRING_ACCOUNT, key)
+    except ApiAuthError:
+        raise
+    except Exception as exc:  # pragma: no cover — backend-specific failures
+        raise ApiAuthError(f"keyring write failed: {exc}") from exc
+
+
+def peek() -> str | None:
+    """Return the stored API key, or ``None`` if none is set. Env override wins."""
+    env = _env_key()
+    if env:
+        return env
+    try:
+        return _keyring_module().get_password(KEYRING_SERVICE, KEYRING_ACCOUNT)
+    except ApiAuthError:
+        raise
+    except Exception:  # pragma: no cover — backend read failures are non-fatal
+        return None
+
+
+def get_or_create_key() -> str:
+    """Return the existing key, generating and persisting a new one if absent."""
+    existing = peek()
+    if existing:
+        return existing
+    key = _generate()
+    _store(key)
+    return key
+
+
+def rotate() -> str:
+    """Generate, store, and return a fresh key, replacing any existing one."""
+    key = _generate()
+    _store(key)
+    return key
+
+
+def clear() -> bool:
+    """Delete the stored key from the keyring. Returns True if one was removed."""
+    try:
+        _keyring_module().delete_password(KEYRING_SERVICE, KEYRING_ACCOUNT)
+        return True
+    except ApiAuthError:
+        raise
+    except Exception:  # no key stored, or backend lacks the entry
+        return False
+
+
+def verify(token: str | None) -> bool:
+    """Constant-time comparison of a presented token against the stored key."""
+    if not token:
+        return False
+    stored = peek()
+    if not stored:
+        return False
+    return secrets.compare_digest(token, stored)
+
+
+def extract_bearer(header_value: str | None) -> str | None:
+    """Pull the token from an ``Authorization: Bearer <token>`` header value.
+
+    Tolerates a bare token (no scheme) for clients that omit ``Bearer``.
+    """
+    if not header_value:
+        return None
+    parts = header_value.split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1].strip() or None
+    return header_value.strip() or None

--- a/oracle/services/chat_engine.py
+++ b/oracle/services/chat_engine.py
@@ -825,6 +825,15 @@ class ChatEngine:
 
     # ── Tool execution ────────────────────────────────────
 
+    def run_tool(self, name: str, args: dict | None = None) -> dict:
+        """Public entry point for dispatching a single tool call.
+
+        Shared by the internal chat loop and the external Discovery API so both
+        route through one dispatch path and can never diverge. ``args`` may be
+        None/empty for no-argument tools.
+        """
+        return self._execute_tool(name, args or {})
+
     def _execute_tool(self, name: str, args: dict) -> dict:
         """Dispatch tool call to the appropriate service."""
         try:

--- a/oracle/services/tool_executor.py
+++ b/oracle/services/tool_executor.py
@@ -1,0 +1,30 @@
+"""Standalone tool-dispatch adapter for the Oracle Discovery API.
+
+The concrete tool implementations live on :class:`~oracle.services.chat_engine.ChatEngine`
+because they share thread-local streaming machinery used by the chat UI (see
+``_agent_tls`` in ``chat_engine.py``). Rather than duplicate that logic, this thin
+adapter routes the external Discovery API through ``ChatEngine.run_tool`` so the
+internal chat loop and the external API share exactly one dispatch path and can
+never diverge.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class ToolHost(Protocol):
+    """Anything that can dispatch a tool by name (duck-typed ChatEngine)."""
+
+    def run_tool(self, name: str, args: dict | None = ...) -> dict: ...
+
+
+class ToolExecutor:
+    """Adapter exposing ``execute(name, args)`` over a tool host."""
+
+    def __init__(self, host: ToolHost):
+        self._host = host
+
+    def execute(self, name: str, args: dict | None = None) -> dict[str, Any]:
+        """Dispatch a single tool call, returning the host's result dict."""
+        return self._host.run_tool(name, args or {})

--- a/oracle/services/tool_registry.py
+++ b/oracle/services/tool_registry.py
@@ -1,0 +1,412 @@
+"""Canonical catalog of Oracle Discovery tools — the single source of truth.
+
+``TOOL_SPECS`` defines every tool exposed to external LLMs: its name, capability
+tier, human/LLM-facing description, and a real JSON Schema for its parameters.
+Both transports consume this list:
+
+* the REST surface (``oracle_server.py``) serves the catalog + a generated
+  OpenAPI document and dispatches calls, and
+* the MCP server (``oracle/mcp_oracle.py``) registers one MCP tool per spec.
+
+The schemas mirror the tools dispatched by ``ChatEngine._execute_tool`` (and the
+``C3Bridge`` methods behind ``_dispatch_c3``). ``c3_filter`` is intentionally
+absent — it is not wired into the chat dispatcher, so it is not callable here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# Capability tiers, lowest privilege first. ``api_max_tier`` (Oracle config)
+# caps which tiers are exposed.
+TIER_READ = "read"
+TIER_ACTION = "action"
+_TIER_RANK = {TIER_READ: 0, TIER_ACTION: 1}
+
+# Reusable schema fragments.
+_PROJECT_PATH = {"type": "string", "description": "Absolute path to the target C3 project."}
+
+
+def _c3_version() -> str:
+    """Read __version__ from cli/c3.py without importing it (heavy side effects)."""
+    try:
+        c3_py = Path(__file__).resolve().parents[2] / "cli" / "c3.py"
+        for line in c3_py.read_text(encoding="utf-8").splitlines():
+            if line.startswith("__version__"):
+                return line.split('"')[1]
+    except Exception:
+        pass
+    return "0"
+
+
+def _obj(properties: dict, required: list[str] | None = None) -> dict:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required or [],
+        "additionalProperties": False,
+    }
+
+
+# ── The catalog ───────────────────────────────────────────
+# Each entry: {name, tier, description, parameters(JSON Schema)}.
+TOOL_SPECS: list[dict[str, Any]] = [
+    # ── read tier: cross-project discovery ──
+    {
+        "name": "list_projects",
+        "tier": TIER_READ,
+        "description": "List all registered C3 projects with paths and fact counts. Start here to discover what is available.",
+        "parameters": _obj({}),
+    },
+    {
+        "name": "search_facts",
+        "tier": TIER_READ,
+        "description": "Search durable memory facts across ALL projects. Returns matches with their source project.",
+        "parameters": _obj(
+            {
+                "query": {"type": "string", "description": "Keyword query (space-separated terms)."},
+                "limit": {"type": "integer", "default": 20, "description": "Max results."},
+            },
+            ["query"],
+        ),
+    },
+    {
+        "name": "query_memory",
+        "tier": TIER_READ,
+        "description": "Search or list durable memory facts within ONE project.",
+        "parameters": _obj(
+            {
+                "project_path": _PROJECT_PATH,
+                "query": {"type": "string", "default": "", "description": "Optional keyword filter on fact text."},
+                "category": {"type": "string", "default": "", "description": "Optional category filter."},
+                "limit": {"type": "integer", "default": 10, "description": "Max results."},
+            },
+            ["project_path"],
+        ),
+    },
+    {
+        "name": "project_health",
+        "tier": TIER_READ,
+        "description": "Run a health check on a project's memory: status, issues, and stats.",
+        "parameters": _obj({"project_path": _PROJECT_PATH}, ["project_path"]),
+    },
+    {
+        "name": "analyze_project",
+        "tier": TIER_READ,
+        "description": "Deep LLM-powered analysis of a project's memory patterns and themes (uses the local Oracle model).",
+        "parameters": _obj({"project_path": _PROJECT_PATH}, ["project_path"]),
+    },
+    {
+        "name": "cross_insights",
+        "tier": TIER_READ,
+        "description": "Get cross-project insights. Omit project_path for all insights, or pass it to filter to one project.",
+        "parameters": _obj(
+            {"project_path": {"type": "string", "default": "", "description": "Optional project filter."}}
+        ),
+    },
+    {
+        "name": "read_graph",
+        "tier": TIER_READ,
+        "description": "Get memory-graph statistics for a project (node/edge/type counts).",
+        "parameters": _obj({"project_path": _PROJECT_PATH}, ["project_path"]),
+    },
+    # ── read tier: C3 code intelligence ──
+    {
+        "name": "c3_search",
+        "tier": TIER_READ,
+        "description": "Code-intelligence search within one project. Use to find which files/symbols are relevant.",
+        "parameters": _obj(
+            {
+                "project_path": _PROJECT_PATH,
+                "query": {"type": "string", "description": "What to search for."},
+                "action": {
+                    "type": "string",
+                    "default": "code",
+                    "enum": ["code", "exact", "files", "semantic", "transcript"],
+                    "description": "Search mode.",
+                },
+                "top_k": {"type": "integer", "default": 3, "description": "Max hits."},
+                "max_tokens": {"type": "integer", "default": 1200, "description": "Token budget for results."},
+            },
+            ["project_path", "query"],
+        ),
+    },
+    {
+        "name": "c3_search_cross",
+        "tier": TIER_READ,
+        "description": "Code-intelligence search across ALL projects. No project_path needed.",
+        "parameters": _obj(
+            {
+                "query": {"type": "string", "description": "What to search for."},
+                "action": {"type": "string", "default": "code", "description": "Search mode (code|exact|files|semantic)."},
+                "top_k": {"type": "integer", "default": 3, "description": "Max hits."},
+            },
+            ["query"],
+        ),
+    },
+    {
+        "name": "c3_read",
+        "tier": TIER_READ,
+        "description": "Read exact file content from a project, optionally narrowed to symbols or line ranges.",
+        "parameters": _obj(
+            {
+                "project_path": _PROJECT_PATH,
+                "file_path": {"type": "string", "description": "Path to the file (relative to the project or absolute)."},
+                "symbols": {"type": "string", "description": "Optional comma-separated symbol names to extract."},
+                "lines": {"type": "string", "description": "Optional line or range, e.g. '10' or '10-40'."},
+            },
+            ["project_path", "file_path"],
+        ),
+    },
+    {
+        "name": "c3_compress",
+        "tier": TIER_READ,
+        "description": "Token-efficient structural map of a file (classes/functions/imports). Use before c3_read.",
+        "parameters": _obj(
+            {
+                "project_path": _PROJECT_PATH,
+                "file_path": {"type": "string", "description": "Path to the file."},
+                "mode": {
+                    "type": "string",
+                    "default": "map",
+                    "enum": ["map", "dense_map", "smart", "diff", "bug_scan", "ast"],
+                    "description": "Compression mode.",
+                },
+            },
+            ["project_path", "file_path"],
+        ),
+    },
+    {
+        "name": "c3_validate",
+        "tier": TIER_READ,
+        "description": "Syntax/type validation on a file in a project.",
+        "parameters": _obj(
+            {"project_path": _PROJECT_PATH, "file_path": {"type": "string", "description": "Path to the file."}},
+            ["project_path", "file_path"],
+        ),
+    },
+    {
+        "name": "c3_status",
+        "tier": TIER_READ,
+        "description": "Project health/budget/sessions overview.",
+        "parameters": _obj(
+            {
+                "project_path": _PROJECT_PATH,
+                "view": {
+                    "type": "string",
+                    "default": "health",
+                    "enum": ["budget", "health", "sessions", "notifications", "ghost_files"],
+                    "description": "Which view to return.",
+                },
+                "detailed": {"type": "boolean", "default": False, "description": "Include extra detail."},
+            },
+            ["project_path"],
+        ),
+    },
+    {
+        "name": "c3_memory_query",
+        "tier": TIER_READ,
+        "description": "Query a project's memory (read-only actions: recall, query, list, score, graph, trends).",
+        "parameters": _obj(
+            {
+                "project_path": _PROJECT_PATH,
+                "action": {"type": "string", "default": "query", "description": "Read-only memory action."},
+                "query": {"type": "string", "default": "", "description": "Query text."},
+                "category": {"type": "string", "default": "", "description": "Optional category."},
+                "top_k": {"type": "integer", "default": 10, "description": "Max results."},
+            },
+            ["project_path"],
+        ),
+    },
+    {
+        "name": "c3_edits",
+        "tier": TIER_READ,
+        "description": "Query a project's edit ledger (history, versions, stats) — read-only audit trail.",
+        "parameters": _obj(
+            {
+                "project_path": _PROJECT_PATH,
+                "action": {"type": "string", "default": "history", "description": "history|versions|stats."},
+                "file": {"type": "string", "default": "", "description": "Optional file filter."},
+                "limit": {"type": "integer", "default": 50, "description": "Max records."},
+                "since": {"type": "string", "default": "", "description": "Optional ISO date lower bound."},
+                "tag": {"type": "string", "default": "", "description": "Optional tag filter."},
+            },
+            ["project_path"],
+        ),
+    },
+    {
+        "name": "c3_edits_cross",
+        "tier": TIER_READ,
+        "description": "Query edit ledgers across ALL projects. No project_path needed.",
+        "parameters": _obj(
+            {
+                "action": {"type": "string", "default": "history", "description": "history|stats."},
+                "tag": {"type": "string", "default": "", "description": "Optional tag filter."},
+                "limit": {"type": "integer", "default": 20, "description": "Max records."},
+            }
+        ),
+    },
+    # ── action tier: safe, non-code-edit ──
+    {
+        "name": "suggest_action",
+        "tier": TIER_ACTION,
+        "description": "Create a PENDING memory suggestion for a human to approve (no direct write).",
+        "parameters": _obj(
+            {
+                "project_path": _PROJECT_PATH,
+                "action": {
+                    "type": "string",
+                    "enum": ["merge_facts", "archive_facts", "add_fact"],
+                    "description": "Kind of suggestion.",
+                },
+                "fact_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Fact IDs involved (may be empty for add_fact).",
+                },
+                "reason": {"type": "string", "description": "Why this is suggested."},
+            },
+            ["project_path", "action", "fact_ids", "reason"],
+        ),
+    },
+    {
+        "name": "delegate_task",
+        "tier": TIER_ACTION,
+        "description": "Delegate a sub-task to a configured Oracle agent and return its result.",
+        "parameters": _obj(
+            {
+                "agent_id": {"type": "string", "description": "ID of an active Oracle agent."},
+                "task": {"type": "string", "description": "Detailed instructions for the agent."},
+            },
+            ["agent_id", "task"],
+        ),
+    },
+]
+
+_SPECS_BY_NAME = {s["name"]: s for s in TOOL_SPECS}
+
+
+class ToolRegistry:
+    """Tier-aware view over ``TOOL_SPECS`` plus validated dispatch.
+
+    Construct with a ``ToolExecutor`` and the configured ``max_tier`` cap.
+    """
+
+    def __init__(self, executor, max_tier: str = TIER_ACTION):
+        self._executor = executor
+        if max_tier not in _TIER_RANK:
+            max_tier = TIER_ACTION
+        self._max_rank = _TIER_RANK[max_tier]
+        self.max_tier = max_tier
+
+    # ── Introspection ──
+    def _available(self) -> list[dict]:
+        return [s for s in TOOL_SPECS if _TIER_RANK[s["tier"]] <= self._max_rank]
+
+    def list_tools(self) -> list[dict]:
+        """Return available tool specs (name/tier/description/parameters)."""
+        return [
+            {
+                "name": s["name"],
+                "tier": s["tier"],
+                "description": s["description"],
+                "parameters": s["parameters"],
+            }
+            for s in self._available()
+        ]
+
+    def tool_names(self) -> list[str]:
+        return [s["name"] for s in self._available()]
+
+    def get_spec(self, name: str) -> dict | None:
+        spec = _SPECS_BY_NAME.get(name)
+        if spec and _TIER_RANK[spec["tier"]] <= self._max_rank:
+            return spec
+        return None
+
+    # ── Dispatch ──
+    def call_tool(self, name: str, args: dict | None = None) -> dict:
+        """Validate tier + required args, then dispatch through the executor.
+
+        Unknown keys are dropped (tools forward args as kwargs). Returns the
+        executor's result dict, or an ``{"error": ...}`` envelope on a bad call.
+        """
+        spec = _SPECS_BY_NAME.get(name)
+        if spec is None:
+            return {"error": f"Unknown tool: {name}"}
+        if _TIER_RANK[spec["tier"]] > self._max_rank:
+            return {"error": f"Tool '{name}' is not available at the configured capability tier "
+                             f"('{self.max_tier}')."}
+        args = dict(args or {})
+        schema = spec["parameters"]
+        declared = set(schema.get("properties", {}).keys())
+        # Drop unknown keys so downstream **kwargs dispatch never TypeErrors.
+        filtered = {k: v for k, v in args.items() if k in declared}
+        missing = [r for r in schema.get("required", []) if filtered.get(r) in (None, "")]
+        if missing:
+            return {"error": f"Tool '{name}' missing required argument(s): {', '.join(missing)}"}
+        return self._executor.execute(name, filtered)
+
+    # ── OpenAPI ──
+    def openapi_spec(self, server_url: str = "") -> dict:
+        """Generate an OpenAPI 3.1 document from the available tool specs."""
+        server_url = (server_url or "").rstrip("/")
+        paths: dict[str, Any] = {
+            "/api/discovery/tools": {
+                "get": {
+                    "operationId": "list_discovery_tools",
+                    "summary": "List available discovery tools and their schemas.",
+                    "security": [{"bearerAuth": []}],
+                    "responses": {"200": {"description": "Tool catalog",
+                                          "content": {"application/json": {"schema": {"type": "object"}}}}},
+                }
+            },
+            "/api/discovery/call": {
+                "post": {
+                    "operationId": "call_discovery_tool",
+                    "summary": "Invoke any tool by name with an args object.",
+                    "security": [{"bearerAuth": []}],
+                    "requestBody": {
+                        "required": True,
+                        "content": {"application/json": {"schema": _obj(
+                            {"tool": {"type": "string"}, "args": {"type": "object"}}, ["tool"])}},
+                    },
+                    "responses": {"200": {"description": "Tool result",
+                                          "content": {"application/json": {"schema": {"type": "object"}}}}},
+                }
+            },
+        }
+        for s in self._available():
+            first_line = s["description"].split(". ")[0].rstrip(".") + "."
+            paths[f"/api/discovery/tools/{s['name']}"] = {
+                "post": {
+                    "operationId": s["name"],
+                    "summary": first_line,
+                    "description": f"{s['description']} (capability tier: {s['tier']})",
+                    "security": [{"bearerAuth": []}],
+                    "requestBody": {
+                        "required": bool(s["parameters"].get("required")),
+                        "content": {"application/json": {"schema": s["parameters"]}},
+                    },
+                    "responses": {"200": {"description": "Tool result",
+                                          "content": {"application/json": {"schema": {"type": "object"}}}}},
+                }
+            }
+        doc: dict[str, Any] = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "C3 Oracle Discovery API",
+                "version": _c3_version(),
+                "description": "Read + safe-action discovery tools over C3's cross-project code and "
+                               "memory intelligence, for use by external LLMs.",
+            },
+            "security": [{"bearerAuth": []}],
+            "components": {
+                "securitySchemes": {"bearerAuth": {"type": "http", "scheme": "bearer"}}
+            },
+            "paths": paths,
+        }
+        if server_url:
+            doc["servers"] = [{"url": server_url}]
+        return doc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "code-context-control"
-version = "2.31.0"
+version = "2.32.0"
 description = "Local code-intelligence layer for AI coding tools (Claude Code, Codex, Gemini, Copilot). Retrieve less, read less, edit safer."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_oracle_api_auth.py
+++ b/tests/test_oracle_api_auth.py
@@ -1,0 +1,94 @@
+"""Tests for oracle/services/api_auth.py.
+
+Replaces the lazy ``_keyring_module()`` with an in-memory stub so the OS keyring
+is never touched. Verifies generate/verify/rotate/clear, the env override, and
+bearer extraction.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from oracle.services import api_auth
+
+
+class _StubKeyring:
+    def __init__(self):
+        self.store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service, account, password):
+        self.store[(service, account)] = password
+
+    def get_password(self, service, account):
+        return self.store.get((service, account))
+
+    def delete_password(self, service, account):
+        if (service, account) not in self.store:
+            raise KeyError("not found")
+        del self.store[(service, account)]
+
+
+class TestApiAuth(unittest.TestCase):
+    def setUp(self):
+        self._stub = _StubKeyring()
+        self._patcher = mock.patch.object(api_auth, "_keyring_module", return_value=self._stub)
+        self._patcher.start()
+        self._env = mock.patch.dict(os.environ, {}, clear=False)
+        self._env.start()
+        os.environ.pop(api_auth.ENV_OVERRIDE, None)
+
+    def tearDown(self):
+        self._patcher.stop()
+        self._env.stop()
+
+    def test_get_or_create_generates_and_persists(self):
+        self.assertIsNone(api_auth.peek())
+        key = api_auth.get_or_create_key()
+        self.assertTrue(key)
+        self.assertGreaterEqual(len(key), 20)
+        self.assertEqual(api_auth.get_or_create_key(), key)  # idempotent
+        self.assertEqual(api_auth.peek(), key)
+
+    def test_verify(self):
+        key = api_auth.get_or_create_key()
+        self.assertTrue(api_auth.verify(key))
+        self.assertFalse(api_auth.verify("wrong"))
+        self.assertFalse(api_auth.verify(""))
+        self.assertFalse(api_auth.verify(None))
+
+    def test_rotate_changes_key(self):
+        k1 = api_auth.get_or_create_key()
+        k2 = api_auth.rotate()
+        self.assertNotEqual(k1, k2)
+        self.assertTrue(api_auth.verify(k2))
+        self.assertFalse(api_auth.verify(k1))
+
+    def test_clear_removes_key(self):
+        api_auth.get_or_create_key()
+        self.assertTrue(api_auth.clear())
+        self.assertIsNone(api_auth.peek())
+        self.assertFalse(api_auth.clear())  # nothing left to remove
+
+    def test_env_override_wins_and_not_persisted(self):
+        os.environ[api_auth.ENV_OVERRIDE] = "env-key-123456789012345"
+        self.assertEqual(api_auth.peek(), "env-key-123456789012345")
+        self.assertTrue(api_auth.verify("env-key-123456789012345"))
+        self.assertEqual(api_auth.get_or_create_key(), "env-key-123456789012345")
+        self.assertEqual(self._stub.store, {})  # env keys never hit the keyring
+
+    def test_extract_bearer(self):
+        self.assertEqual(api_auth.extract_bearer("Bearer abc"), "abc")
+        self.assertEqual(api_auth.extract_bearer("bearer xyz"), "xyz")
+        self.assertEqual(api_auth.extract_bearer("rawtoken"), "rawtoken")
+        self.assertIsNone(api_auth.extract_bearer(""))
+        self.assertIsNone(api_auth.extract_bearer(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_oracle_discovery_api.py
+++ b/tests/test_oracle_discovery_api.py
@@ -1,0 +1,100 @@
+"""Smoke tests for the Oracle Discovery REST API: auth, dispatch, OpenAPI.
+
+Uses Flask's test client with a stub executor so no Ollama/keyring is needed.
+The API key is supplied via the ``C3_ORACLE_API_KEY`` env override.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Deterministic key via env override — read by api_auth at verify time.
+os.environ["C3_ORACLE_API_KEY"] = "test-secret-key"
+
+import oracle.oracle_server as srv  # noqa: E402
+from oracle.services.tool_registry import TIER_ACTION, ToolRegistry  # noqa: E402
+
+
+class _StubExecutor:
+    def execute(self, name, args=None):
+        return {"dispatched": name, "args": args or {}}
+
+
+class TestDiscoveryAPI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        srv._cfg = {
+            "api_enabled": True,
+            "api_require_auth": True,
+            "api_max_tier": "action",
+            "bind_host": "127.0.0.1",
+            "mcp_port": 3332,
+            "mcp_enabled": True,
+        }
+        srv._tool_registry = ToolRegistry(_StubExecutor(), max_tier=TIER_ACTION)
+        srv.app.config["TESTING"] = True
+        cls.client = srv.app.test_client()
+        cls.auth = {"Authorization": "Bearer test-secret-key"}
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ.pop("C3_ORACLE_API_KEY", None)
+
+    def test_tools_requires_auth(self):
+        self.assertEqual(self.client.get("/api/discovery/tools").status_code, 401)
+
+    def test_bad_token_rejected(self):
+        r = self.client.get("/api/discovery/tools", headers={"Authorization": "Bearer nope"})
+        self.assertEqual(r.status_code, 401)
+
+    def test_tools_with_auth(self):
+        r = self.client.get("/api/discovery/tools", headers=self.auth)
+        self.assertEqual(r.status_code, 200)
+        names = {t["name"] for t in r.get_json()["tools"]}
+        self.assertIn("list_projects", names)
+        self.assertIn("c3_search_cross", names)
+
+    def test_no_edit_tool_exposed(self):
+        r = self.client.get("/api/discovery/tools", headers=self.auth)
+        names = {t["name"] for t in r.get_json()["tools"]}
+        self.assertNotIn("c3_edit", names)
+        self.assertNotIn("c3_shell", names)
+
+    def test_call_dispatches(self):
+        r = self.client.post("/api/discovery/call",
+                             json={"tool": "list_projects", "args": {}}, headers=self.auth)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["dispatched"], "list_projects")
+
+    def test_call_missing_tool(self):
+        r = self.client.post("/api/discovery/call", json={"args": {}}, headers=self.auth)
+        self.assertEqual(r.status_code, 400)
+
+    def test_call_named(self):
+        r = self.client.post("/api/discovery/tools/c3_search_cross",
+                             json={"query": "x"}, headers=self.auth)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["dispatched"], "c3_search_cross")
+
+    def test_openapi(self):
+        r = self.client.get("/api/discovery/openapi.json", headers=self.auth)
+        self.assertEqual(r.status_code, 200)
+        spec = r.get_json()
+        self.assertEqual(spec["openapi"], "3.1.0")
+        self.assertIn("/api/discovery/tools/list_projects", spec["paths"])
+
+    def test_mcp_info(self):
+        r = self.client.get("/api/discovery/mcp-info", headers=self.auth)
+        self.assertEqual(r.status_code, 200)
+        info = r.get_json()
+        self.assertEqual(info["auth"], "bearer")
+        self.assertTrue(info["url"].endswith("/mcp"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,91 @@
+"""Tests for oracle/services/tool_registry.py — tiers, dispatch, OpenAPI."""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from oracle.services.tool_registry import TIER_ACTION, TIER_READ, TOOL_SPECS, ToolRegistry
+
+
+class _RecordingExecutor:
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    def execute(self, name, args=None):
+        self.calls.append((name, args))
+        return {"ok": True, "name": name, "args": args}
+
+
+class TestToolRegistry(unittest.TestCase):
+    def setUp(self):
+        self.exec = _RecordingExecutor()
+
+    def test_all_specs_have_object_schema(self):
+        for spec in TOOL_SPECS:
+            self.assertIn(spec["tier"], (TIER_READ, TIER_ACTION))
+            params = spec["parameters"]
+            self.assertEqual(params.get("type"), "object")
+            self.assertIn("properties", params)
+            self.assertIn("required", params)
+
+    def test_no_code_edit_tools(self):
+        names = {s["name"] for s in TOOL_SPECS}
+        for forbidden in ("c3_edit", "edit", "c3_shell", "write", "c3_delegate"):
+            self.assertNotIn(forbidden, names)
+
+    def test_tier_filtering(self):
+        read_only = set(ToolRegistry(self.exec, max_tier=TIER_READ).tool_names())
+        self.assertIn("c3_search", read_only)
+        self.assertNotIn("suggest_action", read_only)
+        self.assertNotIn("delegate_task", read_only)
+
+        full = set(ToolRegistry(self.exec, max_tier=TIER_ACTION).tool_names())
+        self.assertIn("suggest_action", full)
+        self.assertIn("delegate_task", full)
+
+    def test_call_tool_filters_unknown_args(self):
+        reg = ToolRegistry(self.exec, max_tier=TIER_ACTION)
+        out = reg.call_tool("c3_search", {"project_path": "/p", "query": "x", "bogus": 1})
+        self.assertTrue(out["ok"])
+        name, args = self.exec.calls[-1]
+        self.assertEqual(name, "c3_search")
+        self.assertNotIn("bogus", args)
+        self.assertEqual(args["project_path"], "/p")
+
+    def test_call_tool_missing_required(self):
+        reg = ToolRegistry(self.exec, max_tier=TIER_ACTION)
+        out = reg.call_tool("c3_search", {"project_path": "/p"})  # query missing
+        self.assertIn("error", out)
+        self.assertEqual(self.exec.calls, [])
+
+    def test_call_tool_tier_blocked(self):
+        reg = ToolRegistry(self.exec, max_tier=TIER_READ)
+        out = reg.call_tool("delegate_task", {"agent_id": "a", "task": "t"})
+        self.assertIn("error", out)
+        self.assertEqual(self.exec.calls, [])
+
+    def test_call_tool_unknown(self):
+        reg = ToolRegistry(self.exec, max_tier=TIER_ACTION)
+        self.assertIn("error", reg.call_tool("does_not_exist", {}))
+
+    def test_openapi_has_path_per_tool(self):
+        reg = ToolRegistry(self.exec, max_tier=TIER_ACTION)
+        spec = reg.openapi_spec("http://127.0.0.1:3331/")
+        self.assertEqual(spec["openapi"], "3.1.0")
+        for name in reg.tool_names():
+            self.assertIn(f"/api/discovery/tools/{name}", spec["paths"])
+        self.assertIn("bearerAuth", spec["components"]["securitySchemes"])
+        self.assertEqual(spec["servers"][0]["url"], "http://127.0.0.1:3331")
+
+    def test_openapi_excludes_blocked_tier(self):
+        reg = ToolRegistry(self.exec, max_tier=TIER_READ)
+        spec = reg.openapi_spec()
+        self.assertNotIn("/api/discovery/tools/delegate_task", spec["paths"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the **Oracle Discovery API (v2.32.0)** — external LLMs (Claude Code/Desktop and any function-calling model) can point at a running Oracle and use C3's cross-project code & memory intelligence as tools, over **MCP (HTTP/SSE)** and a parallel **OpenAPI REST** surface that share one tool core.

- **Capabilities:** read + safe-action tiers (`suggest_action` creates *pending* suggestions, `delegate_task`); **no code-editing tools** exposed.
- **Auth / network:** Bearer token (OS keyring, `C3_ORACLE_API_KEY` env override); both servers bind `127.0.0.1` by default.

## How it works

`ToolRegistry` (`oracle/services/tool_registry.py`) is the single source of truth — `TOOL_SPECS` defines 18 tools with JSON Schemas + capability tiers, and generates the OpenAPI 3.1 doc. Both transports dispatch through `ToolExecutor` → the new public `ChatEngine.run_tool()`, so chat and the API never diverge. The MCP server (`oracle/mcp_oracle.py`) builds a FastMCP HTTP/SSE app from the registry and serves it in a daemon thread behind a pure-ASGI Bearer middleware.

## Connect

`c3 oracle api info` prints the token, REST/MCP URLs, and a ready-to-paste Claude `.mcp.json` snippet. Generic LLMs use `GET /api/discovery/openapi.json`.

## Reviewer notes / decisions

- **Version is 2.32.0** — `2.31.0` was already taken by the cross-project-tools feature on `main`.
- **`ToolExecutor` is an adapter, not a physical code move.** `_tool_delegate_task` is entangled with `chat()`'s thread-local streaming queue; the adapter delivers single-source-of-truth with zero behavioral risk.
- **Oracle now binds `127.0.0.1` by default** (was `0.0.0.0`) — intentional per the loopback security choice. Override via `bind_host` in `~/.c3/oracle/config.json`.
- **MCP auth uses a pure-ASGI middleware** — Starlette's `BaseHTTPMiddleware` would buffer responses and break MCP SSE streaming.
- `c3_filter` is intentionally not exposed — it isn't wired into the chat dispatcher.

## Tests / verification

- 24 new tests (`test_oracle_api_auth`, `test_tool_registry`, `test_oracle_discovery_api`).
- Full suite: **239 passed**; `ruff` clean; all changed Python type/syntax-validated.
- End-to-end MCP smoke verified manually: 401 without auth; with auth the `/mcp` endpoint returns a real `initialize` result over SSE.

## Files

New: `oracle/services/api_auth.py`, `tool_registry.py`, `tool_executor.py`, `oracle/mcp_oracle.py`, 3 test files, `guide/oracle.html`, `oracle-guide/discovery-api.md`. Modified: `oracle/oracle_server.py`, `oracle/config.py`, `oracle/services/chat_engine.py`, `cli/c3.py`, `cli/commands/parser.py`, guide nav + `api-reference.md` + `oracle-guide/README.md`, `CHANGELOG.md`, `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
