### PR TITLE
feat(2.32.1): Discovery API token management in the Oracle dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.1] - 2026-06-09
+
+UI follow-up to the Discovery API: manage the Bearer token from the Oracle dashboard.
+
+### Added
+
+- Oracle dashboard **Settings → Discovery API** section: generate / rotate / clear the
+  Bearer token, reveal + copy it, and copy a ready-to-paste Claude `.mcp.json` snippet,
+  alongside live MCP URL / REST base / OpenAPI links.
+- `GET /api/apikey` + `POST /api/apikey/{generate,rotate,clear}` — local-dashboard
+  (loopback, unauthenticated, like `/api/config`) endpoints backing the token UI.
+- Tests: `test_oracle_apikey_api.py`.
+
 ## [2.32.0] - 2026-06-09
 
 Feature release. The **Oracle Discovery API** lets external LLMs — Claude Code /

--- a/cli/c3.py
+++ b/cli/c3.py
@@ -85,7 +85,7 @@ console = Console() if HAS_RICH else None
 # Config
 CONFIG_DIR = ".c3"
 CONFIG_FILE = ".c3/config.json"
-__version__ = "2.32.0"
+__version__ = "2.32.1"
 
 
 def _command_deps() -> CommandDeps:

--- a/guide/oracle.html
+++ b/guide/oracle.html
@@ -171,7 +171,7 @@
         <div class="step-card">
           <span class="step-num">2</span><h4>Get the token</h4>
           <pre><code>c3 oracle api info</code></pre>
-          <p style="font-size: 12px; color: var(--text-dim); margin: 8px 0 0;">Prints the Bearer token, both URLs, and a ready-to-paste Claude <code>.mcp.json</code> entry. Use <code>c3 oracle api key</code> for just the token.</p>
+          <p style="font-size: 12px; color: var(--text-dim); margin: 8px 0 0;">Prints the Bearer token, both URLs, and a ready-to-paste Claude <code>.mcp.json</code> entry. Use <code>c3 oracle api key</code> for just the token. You can also generate, rotate, and copy the token visually in the Oracle dashboard under <strong>Settings → Discovery API</strong>.</p>
         </div>
         <div class="step-card">
           <span class="step-num">3</span><h4>Connect</h4>

--- a/oracle-guide/discovery-api.md
+++ b/oracle-guide/discovery-api.md
@@ -34,6 +34,9 @@ c3 oracle api rotate      # replace the token
 c3 oracle api clear       # delete the stored token
 ```
 
+You can also generate, rotate, and copy the token from the **Oracle dashboard →
+Settings → Discovery API** (it shows the live MCP URL, REST base, and `.mcp.json` snippet).
+
 The token lives in your OS keyring (Windows Credential Manager / macOS Keychain /
 Linux Secret Service). For headless/CI, set `C3_ORACLE_API_KEY` instead — it
 overrides the keyring and is never persisted.

--- a/oracle/oracle.html
+++ b/oracle/oracle.html
@@ -1088,6 +1088,45 @@
       </div>
       <div id="settingsMsg" class="status-msg"></div>
     </div>
+
+    <!-- ── Discovery API (external LLM tools) ── -->
+    <h2 style="font-size:16px;font-weight:600;margin:28px 0 16px">Discovery API <span style="font-size:11px;color:var(--text2);font-weight:400">— external LLM tools (v2.32.0)</span></h2>
+    <div class="card">
+      <p style="font-size:12px;color:var(--text2);margin:0 0 14px;line-height:1.5">Let Claude or any LLM use C3's cross-project tools over MCP and OpenAPI. Requests authenticate with a <b>Bearer token</b>; both servers bind <code>127.0.0.1</code> by default.</p>
+      <div class="field">
+        <label>API token</label>
+        <div style="display:flex;align-items:center;gap:8px">
+          <input id="dkToken" type="password" readonly placeholder="No token yet — click Generate" style="flex:1;width:0;min-width:0;font-family:var(--mono,monospace)">
+          <button class="btn btn-ghost" id="dkReveal" onclick="toggleDiscoveryReveal()" style="flex-shrink:0;display:none">Reveal</button>
+          <button class="btn btn-ghost" onclick="copyDiscoveryToken()" style="flex-shrink:0">Copy</button>
+        </div>
+        <div id="dkStatus" style="font-size:11px;color:var(--text2);margin-top:6px"></div>
+      </div>
+      <div style="display:flex;gap:8px;margin-top:4px">
+        <button class="btn btn-primary" id="dkGenBtn" onclick="generateDiscoveryKey()">Generate token</button>
+        <button class="btn btn-ghost" onclick="rotateDiscoveryKey()">Rotate</button>
+        <button class="btn btn-ghost" onclick="clearDiscoveryKey()">Clear</button>
+      </div>
+      <hr style="border:none;border-top:1px solid var(--border);margin:18px 0">
+      <div class="field">
+        <label>MCP URL (Claude / MCP clients)</label>
+        <input id="dkMcpUrl" type="text" readonly>
+      </div>
+      <div class="field">
+        <label>REST base (any function-calling LLM)</label>
+        <input id="dkRestBase" type="text" readonly>
+      </div>
+      <div class="field">
+        <label>OpenAPI spec</label>
+        <input id="dkOpenapi" type="text" readonly>
+      </div>
+      <div class="field">
+        <label>Claude <code>.mcp.json</code> entry</label>
+        <pre id="dkSnippet" style="background:var(--bg3);border:1px solid var(--border);border-radius:6px;padding:10px;font-size:11px;overflow:auto;margin:0;white-space:pre"></pre>
+        <button class="btn btn-ghost" onclick="copyMcpSnippet()" style="margin-top:8px">Copy .mcp.json</button>
+      </div>
+      <div id="discoveryMsg" class="status-msg"></div>
+    </div>
   </div>
 
   <!-- Agent Modal -->
@@ -1127,7 +1166,7 @@
 
 <script>
 const API = '';
-const ORACLE_BUILD_TIME = "2026-04-11 oracle-v2";
+const ORACLE_BUILD_TIME = "2026-06-09 oracle-v2 (discovery-api)";
 
 // ═══════════════════════════════════════════════════════════
 // ─�� Toast notification system ──
@@ -1994,6 +2033,95 @@ async function testConnection() {
     const resp = result.response || 'No response';
     toast('Ollama response', resp, resp.includes('No response') ? 'warning' : 'success', 6000);
   }, { silent: true });
+}
+
+// ── Discovery API token management ──
+window._discoveryKey = null;
+window._dkRevealed = false;
+
+function _renderDiscoveryKey(s) {
+  window._discoveryKey = s;
+  const tok = document.getElementById('dkToken');
+  if (!tok) return;
+  const reveal = document.getElementById('dkReveal');
+  const genBtn = document.getElementById('dkGenBtn');
+  const status = document.getElementById('dkStatus');
+  if (s.exists) {
+    tok.value = s.key || '';
+    tok.type = window._dkRevealed ? 'text' : 'password';
+    tok.placeholder = '';
+    reveal.style.display = '';
+    reveal.textContent = window._dkRevealed ? 'Hide' : 'Reveal';
+    genBtn.style.display = 'none';
+    status.textContent = s.require_auth
+      ? 'Token active — required on all /api/discovery requests and the MCP transport.'
+      : 'Token set, but auth is DISABLED (api_require_auth=false in config).';
+  } else {
+    tok.value = '';
+    tok.type = 'password';
+    tok.placeholder = 'No token yet — click Generate';
+    reveal.style.display = 'none';
+    genBtn.style.display = '';
+    status.textContent = s.require_auth
+      ? 'No token yet. Generate one so external LLMs can authenticate.'
+      : 'Auth is disabled — external requests are accepted without a token.';
+  }
+  document.getElementById('dkMcpUrl').value = s.mcp_enabled ? s.mcp_url : s.mcp_url + '  (MCP server disabled)';
+  document.getElementById('dkRestBase').value = s.rest_base;
+  document.getElementById('dkOpenapi').value = s.openapi_url;
+  document.getElementById('dkSnippet').textContent = JSON.stringify(s.snippet, null, 2);
+}
+
+async function loadDiscoveryKey() {
+  try { _renderDiscoveryKey(await api('/api/apikey')); } catch { /* ignore */ }
+}
+
+function toggleDiscoveryReveal() {
+  window._dkRevealed = !window._dkRevealed;
+  if (window._discoveryKey) _renderDiscoveryKey(window._discoveryKey);
+}
+
+async function generateDiscoveryKey() {
+  await tracked('Generating token', async () => {
+    const s = await api('/api/apikey/generate', { method: 'POST' });
+    window._dkRevealed = true;
+    _renderDiscoveryKey(s);
+  }, { successMsg: 'Discovery API token generated' });
+}
+
+async function rotateDiscoveryKey() {
+  if (!confirm('Rotate the Discovery API token? Clients using the old token will stop working until updated.')) return;
+  await tracked('Rotating token', async () => {
+    const s = await api('/api/apikey/rotate', { method: 'POST' });
+    window._dkRevealed = true;
+    _renderDiscoveryKey(s);
+  }, { successMsg: 'Token rotated — update your clients' });
+}
+
+async function clearDiscoveryKey() {
+  if (!confirm('Delete the Discovery API token? External LLMs cannot authenticate until you generate a new one.')) return;
+  await tracked('Clearing token', async () => {
+    const s = await api('/api/apikey/clear', { method: 'POST' });
+    window._dkRevealed = false;
+    _renderDiscoveryKey(s);
+  }, { successMsg: 'Token cleared' });
+}
+
+async function copyDiscoveryToken() {
+  const s = window._discoveryKey;
+  if (!s || !s.exists || !s.key) { toast('No token', 'Generate a token first.', 'warning'); return; }
+  await _dkCopy(s.key, 'Token copied');
+}
+
+async function copyMcpSnippet() {
+  const s = window._discoveryKey;
+  if (!s) return;
+  await _dkCopy(JSON.stringify(s.snippet, null, 2), '.mcp.json copied');
+}
+
+async function _dkCopy(text, okMsg) {
+  try { await navigator.clipboard.writeText(text); toast(okMsg, '', 'success', 2000); }
+  catch { toast('Copy failed', 'Select the field and copy manually.', 'error'); }
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -3891,7 +4019,7 @@ function editAgent(id) {
 // ── Init ──
 // ═══════════════════════════════════════════════════════════
 (async function init() {
-  await Promise.all([refreshHeader(), loadProjects(), loadInsights(), loadSuggestions(), loadSettings(), chatLoadConversations(), chatLoadCommands()]);
+  await Promise.all([refreshHeader(), loadProjects(), loadInsights(), loadSuggestions(), loadSettings(), loadDiscoveryKey(), chatLoadConversations(), chatLoadCommands()]);
   // Auto-refresh every 60s
   setInterval(() => { refreshHeader(); loadProjects(); }, 60000);
 })();

--- a/oracle/oracle_server.py
+++ b/oracle/oracle_server.py
@@ -20,6 +20,7 @@ from flask import Flask, Response, jsonify, request, send_from_directory  # noqa
 
 from oracle.config import ORACLE_DIR, load_config, save_config  # noqa: E402
 from oracle.mcp_oracle import mcp_url, start_mcp_thread  # noqa: E402
+from oracle.services import api_auth  # noqa: E402
 from oracle.services.api_auth import extract_bearer  # noqa: E402
 from oracle.services.api_auth import verify as verify_api_key  # noqa: E402
 from oracle.services.c3_bridge import C3Bridge  # noqa: E402
@@ -682,6 +683,79 @@ def api_discovery_mcp_info():
         "auth": "bearer",
         "rest_base": request.host_url.rstrip("/") + "/api/discovery",
     })
+
+
+# ── Discovery API key management (local dashboard — unauthenticated, loopback) ──
+def _apikey_status() -> dict:
+    """Status payload for the Discovery API token + connection info."""
+    key = api_auth.peek()
+    host = _cfg.get("bind_host", "127.0.0.1")
+    port = int(_cfg.get("mcp_port", 3332))
+    url = mcp_url(host, port)
+    rest_base = request.host_url.rstrip("/") + "/api/discovery"
+    masked = ""
+    if key:
+        masked = (key[:4] + "…" + key[-4:]) if len(key) > 12 else "••••"
+    snippet = {
+        "mcpServers": {
+            "c3-oracle": {
+                "type": "http",
+                "url": url,
+                "headers": {"Authorization": f"Bearer {key or '<token>'}"},
+            }
+        }
+    }
+    return {
+        "exists": bool(key),
+        "key": key or "",
+        "masked": masked,
+        "require_auth": bool(_cfg.get("api_require_auth", True)),
+        "api_enabled": bool(_cfg.get("api_enabled", True)),
+        "mcp_enabled": bool(_cfg.get("mcp_enabled", True)),
+        "mcp_url": url,
+        "rest_base": rest_base,
+        "openapi_url": rest_base + "/openapi.json",
+        "snippet": snippet,
+    }
+
+
+@app.route("/api/apikey", methods=["GET"])
+def api_apikey_get():
+    """Return the Discovery API token (if any) + connection info."""
+    try:
+        return jsonify(_apikey_status())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/apikey/generate", methods=["POST"])
+def api_apikey_generate():
+    """Create a token if none exists; returns the current status."""
+    try:
+        api_auth.get_or_create_key()
+        return jsonify(_apikey_status())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/apikey/rotate", methods=["POST"])
+def api_apikey_rotate():
+    """Replace the token with a fresh one."""
+    try:
+        api_auth.rotate()
+        return jsonify(_apikey_status())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/apikey/clear", methods=["POST"])
+def api_apikey_clear():
+    """Delete the stored token."""
+    try:
+        api_auth.clear()
+        return jsonify(_apikey_status())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 
 # ── Error handlers ────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "code-context-control"
-version = "2.32.0"
+version = "2.32.1"
 description = "Local code-intelligence layer for AI coding tools (Claude Code, Codex, Gemini, Copilot). Retrieve less, read less, edit safer."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_oracle_apikey_api.py
+++ b/tests/test_oracle_apikey_api.py
@@ -1,0 +1,101 @@
+"""Tests for the Oracle dashboard token-management endpoints (/api/apikey/*).
+
+These are local-dashboard endpoints (NOT under /api/discovery, so not Bearer-gated).
+``api_auth`` is replaced with an in-memory fake so no keyring/env is touched.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import oracle.oracle_server as srv  # noqa: E402
+
+
+class _FakeAuth:
+    def __init__(self):
+        self.key = None
+
+    def peek(self):
+        return self.key
+
+    def get_or_create_key(self):
+        if not self.key:
+            self.key = "generated-key-abcdef0123456789"
+        return self.key
+
+    def rotate(self):
+        self.key = "rotated-key-9876543210fedcba"
+        return self.key
+
+    def clear(self):
+        had = self.key is not None
+        self.key = None
+        return had
+
+
+class TestApikeyAPI(unittest.TestCase):
+    def setUp(self):
+        self.fake = _FakeAuth()
+        self._patch = mock.patch.object(srv, "api_auth", self.fake)
+        self._patch.start()
+        srv._cfg = {
+            "bind_host": "127.0.0.1", "mcp_port": 3332,
+            "api_require_auth": True, "api_enabled": True, "mcp_enabled": True,
+        }
+        srv.app.config["TESTING"] = True
+        self.client = srv.app.test_client()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_get_no_token_is_ungated(self):
+        # No Authorization header — dashboard endpoint must not be Bearer-gated.
+        r = self.client.get("/api/apikey")
+        self.assertEqual(r.status_code, 200)
+        body = r.get_json()
+        self.assertFalse(body["exists"])
+        self.assertEqual(body["key"], "")
+        self.assertTrue(body["require_auth"])
+        self.assertTrue(body["mcp_url"].endswith("/mcp"))
+        self.assertTrue(body["openapi_url"].endswith("/api/discovery/openapi.json"))
+        self.assertIn("c3-oracle", body["snippet"]["mcpServers"])
+
+    def test_generate(self):
+        r = self.client.post("/api/apikey/generate")
+        self.assertEqual(r.status_code, 200)
+        body = r.get_json()
+        self.assertTrue(body["exists"])
+        self.assertEqual(body["key"], "generated-key-abcdef0123456789")
+        self.assertTrue(body["masked"])
+        self.assertEqual(
+            body["snippet"]["mcpServers"]["c3-oracle"]["headers"]["Authorization"],
+            "Bearer generated-key-abcdef0123456789",
+        )
+
+    def test_rotate_changes_key(self):
+        self.client.post("/api/apikey/generate")
+        r = self.client.post("/api/apikey/rotate")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["key"], "rotated-key-9876543210fedcba")
+
+    def test_clear(self):
+        self.client.post("/api/apikey/generate")
+        r = self.client.post("/api/apikey/clear")
+        self.assertEqual(r.status_code, 200)
+        body = r.get_json()
+        self.assertFalse(body["exists"])
+        self.assertEqual(body["key"], "")
+
+    def test_snippet_placeholder_when_no_key(self):
+        r = self.client.get("/api/apikey")
+        auth = r.get_json()["snippet"]["mcpServers"]["c3-oracle"]["headers"]["Authorization"]
+        self.assertEqual(auth, "Bearer <token>")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a **Settings → Discovery API** section to the Oracle web dashboard for managing the Bearer token introduced in 2.32.0 — generate, rotate, clear, reveal, and copy the token, with live MCP / REST / OpenAPI URLs and a copyable Claude `.mcp.json` snippet.

## Backend

`oracle/oracle_server.py` gains four **local-dashboard** endpoints — loopback, unauthenticated (like `/api/config`), and deliberately *not* under the Bearer-gated `/api/discovery/*`:

- `GET /api/apikey` — token status + connection info (key, masked, MCP URL, REST base, OpenAPI URL, `.mcp.json` snippet)
- `POST /api/apikey/generate` — create if absent
- `POST /api/apikey/rotate` — replace
- `POST /api/apikey/clear` — delete

They delegate to the existing keyring-backed `oracle/services/api_auth.py`.

## Frontend

`oracle/oracle.html` — a Discovery API card in the Settings panel: read-only token field with reveal/copy, Generate / Rotate / Clear buttons (rotate & clear confirm first), live MCP URL / REST base / OpenAPI fields, and a copyable `.mcp.json` block. Loaded on dashboard init.

## Docs / version

- `guide/oracle.html` + `oracle-guide/discovery-api.md` note the dashboard UI.
- Version bumped to **2.32.1**; CHANGELOG entry added.

## Tests

- `tests/test_oracle_apikey_api.py` — 5 new (ungated access, generate/rotate/clear, snippet placeholder), with `api_auth` stubbed (no keyring touched).
- Full suite: **244 passed**; `ruff` clean.

## Security note

The token endpoints live on the unauthenticated local dashboard by design — consistent with `/api/config`, which already exposes the Ollama key locally. Anyone with loopback access to the dashboard can already read config, so the Discovery token follows the same trust boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
