### PR TITLE
docs: add Oracle Discovery API section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,34 @@ to the C3 edit ledger so the audit trail covers platform-side changes too.
 The **Hub UI** (per-project) gains a "Bitbucket" tab with sub-views for
 Overview / Pull Requests / Branches / Activity / Admin.
 
+### Oracle Discovery API (v2.32.0)
+
+The **Oracle** is C3's optional cross-project memory agent (a local web app). As of
+v2.32.0 it can expose C3's cross-project code & memory intelligence as **tools for an
+external LLM** — point Claude (or any function-calling model) at a running Oracle and
+it can discover your projects and search code, memory, and the cross-project graph
+across all of them.
+
+Two transports share one tool core:
+
+- **MCP** (streamable HTTP/SSE) at `http://127.0.0.1:3332/mcp` — native for Claude
+  Code / Claude Desktop / any MCP client.
+- **OpenAPI REST** at `http://127.0.0.1:3331/api/discovery` — for any LLM with
+  function-calling (fetch `/openapi.json` to auto-register the tools).
+
+```bash
+# Start the Oracle (serves the REST + MCP discovery endpoints)
+python oracle/oracle_server.py --no-browser
+
+# Print the Bearer token + a ready-to-paste .mcp.json snippet
+c3 oracle api info
+```
+
+Only **read** and **safe-action** tools are exposed (no code editing); requests need a
+**Bearer token** (stored in the OS keyring) and both servers bind `127.0.0.1` by
+default. Generate, rotate, and copy the token from the dashboard's **Settings →
+Discovery API** tab. See the [Oracle Discovery API guide](oracle-guide/discovery-api.md).
+
 ---
 
 ## Tiered local AI (optional)
@@ -293,6 +321,7 @@ The author may introduce a paid offering or relicense future major versions; no 
 
 - **PyPI:** https://pypi.org/project/code-context-control/
 - **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
+- **Oracle Discovery API:** [`oracle-guide/discovery-api.md`](oracle-guide/discovery-api.md)
 - **Security policy:** [`SECURITY.md`](SECURITY.md)
 - **Licensing FAQ:** [`LICENSING.md`](LICENSING.md)
 - **Issues:** https://github.com/drknowhow/code-context-control/issues


### PR DESCRIPTION
## Summary

The Oracle and its Discovery API (v2.32.0 / v2.32.1) had **no mention in the README** — which is also the PyPI long description, so the headline feature of the last two releases was invisible on both the GitHub front page and the PyPI project page.

This adds an **Oracle Discovery API (v2.32.0)** section under the tool suite, mirroring the existing Bitbucket section:

- the two transports (MCP HTTP/SSE + OpenAPI REST),
- how to start the Oracle and get a token (`c3 oracle api info`),
- the read/safe-action + Bearer + loopback security model,
- dashboard token management (Settings → Discovery API),
- and a link to `oracle-guide/discovery-api.md` (also added to the Links section).

## Notes

- **Docs-only — no version bump.** The PyPI page renders the README, and a release's README is frozen at build time, so this lands on PyPI only with the next release. Happy to cut a `2.32.2` docs release (bump + tag) once this is merged if you want it reflected on PyPI now.
- The CHANGELOG already carries 2.31.0/2.32.0/2.32.1, and PyPI already links it via the `[project.urls] Changelog` sidebar entry. The v2.32.1 GitHub release notes were also enriched with curated highlights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
