### PR TITLE
chore(release): 2.32.2 docs release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.2] - 2026-06-09
+
+Docs release — no functional changes.
+
+### Changed
+
+- README now documents the **Oracle Discovery API** (v2.32.0): the MCP + OpenAPI
+  transports, the `c3 oracle api` token workflow, the read/safe-action + Bearer +
+  loopback security model, and dashboard token management. Since PyPI renders the
+  README as the project description, this surfaces the Oracle work (shipped in the
+  2.32.x line) on the PyPI and GitHub project pages.
+
 ## [2.32.1] - 2026-06-09
 
 UI follow-up to the Discovery API: manage the Bearer token from the Oracle dashboard.

--- a/cli/c3.py
+++ b/cli/c3.py
@@ -85,7 +85,7 @@ console = Console() if HAS_RICH else None
 # Config
 CONFIG_DIR = ".c3"
 CONFIG_FILE = ".c3/config.json"
-__version__ = "2.32.1"
+__version__ = "2.32.2"
 
 
 def _command_deps() -> CommandDeps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "code-context-control"
-version = "2.32.1"
+version = "2.32.2"
 description = "Local code-intelligence layer for AI coding tools (Claude Code, Codex, Gemini, Copilot). Retrieve less, read less, edit safer."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump to 2.32.2 + CHANGELOG entry for the docs release. Brings the README Oracle Discovery API section (merged in #6) to the PyPI project page. No functional changes.