### PR TITLE
fix: eliminate 0-byte ghost files from shell-redirect misinterpretation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Ghost files (0-byte) from shell-redirect misinterpretation.** The output filter
+  emitted its savings header as `raw->Ntok`; the literal `->` could be re-read by a
+  shell as a `> Ntok` redirect, creating an empty file named after the token count.
+  The header now uses `→` (not a shell metacharacter). The ghost-file cleanup hook
+  (`hook_ghost_files.py`) also now runs after `c3_shell`, `c3_read`, and `Read` — not
+  just `Bash` — so ghosts from any tool's output (git `ref -> ref`, Python `-> Type`,
+  pip `>=x`) get swept. Re-run `c3 install-mcp` to register the new hook matchers.
+
 ## [2.32.2] - 2026-06-09
 
 Docs release — no functional changes.

--- a/cli/c3.py
+++ b/cli/c3.py
@@ -4962,13 +4962,24 @@ def cmd_install_mcp(args):
             },
             {
                 "matcher": read_matcher,
-                "hooks": [{"type": "command", "command": hook_read_cmd}]
+                "hooks": [
+                    {"type": "command", "command": hook_read_cmd},
+                    {"type": "command", "command": hook_ghost_files_cmd},
+                ]
             },
             {
                 "matcher": "mcp__c3__c3_read",
                 "hooks": [
                     {"type": "command", "command": hook_c3read_cmd},
                     {"type": "command", "command": hook_c3_signal_cmd},
+                    {"type": "command", "command": hook_ghost_files_cmd},
+                ]
+            },
+            {
+                "matcher": "mcp__c3__c3_shell",
+                "hooks": [
+                    {"type": "command", "command": hook_c3_signal_cmd},
+                    {"type": "command", "command": hook_ghost_files_cmd},
                 ]
             },
             {

--- a/cli/hook_ghost_files.py
+++ b/cli/hook_ghost_files.py
@@ -212,6 +212,17 @@ def cleanup_ghost_files(ghosts: list[dict]) -> list[str]:
     return deleted
 
 
+# Tools whose output can carry shell-meta text that leaks into 0-byte files:
+# native shells, c3_shell (its `N->Mtok` filter header), and file reads whose
+# content has `-> Type` hints. A downstream shell sees `> word` and creates an
+# empty file named `word`.
+_GHOST_TRIGGER_TOOLS = (
+    "Bash", "run_shell_command",
+    "mcp__c3__c3_shell",
+    "mcp__c3__c3_read", "Read", "read_file",
+)
+
+
 def main():
     try:
         raw = sys.stdin.read()
@@ -221,8 +232,7 @@ def main():
         data = json.loads(raw)
         tool_name = data.get("tool_name", "")
 
-        # Only trigger on Bash (Claude Code) or run_shell_command (Gemini)
-        if tool_name not in ("Bash", "run_shell_command"):
+        if tool_name not in _GHOST_TRIGGER_TOOLS:
             return
 
         is_gemini = isinstance(data.get("tool_response", ""), dict)

--- a/cli/tools/filter.py
+++ b/cli/tools/filter.py
@@ -64,10 +64,10 @@ def _filter_text(text: str, depth: str, svc, finalize) -> str:
     raw_tokens = res['raw_tokens']
     savings_pct = round((1 - filtered_tokens / raw_tokens) * 100, 1) if raw_tokens > 0 else 0
 
-    header = f"[filter:{method}] {raw_tokens}->{filtered_tokens}tok ({savings_pct}%saved)"
+    header = f"[filter:{method}] {raw_tokens}→{filtered_tokens}tok ({savings_pct}%saved)"
     resp = f"{header}\n{result_text}"
     return finalize("c3_filter", {"depth": depth},
-                    resp, f"{raw_tokens}->{filtered_tokens}tok",
+                    resp, f"{raw_tokens}→{filtered_tokens}tok",
                     response_tokens=filtered_tokens)
 
 


### PR DESCRIPTION
## The bug

0-byte "ghost" files (e.g. `110tok`, `69tok`, `main`, `str`) kept appearing in the project root. Despite the suspicion, **it is not caused by `&`.**

**Root cause:** text containing `-> word` reaches a shell, which parses `> word` as a redirection and creates an empty file named `word`. The biggest source was c3's *own* output filter, which formats its savings header as `raw->Ntok` — the literal `->` becomes `> Ntok`.

Reproduced live: a `git log` command (no `->` in its own output) was filtered with header `818->69tok`, and a 0-byte `69tok` immediately appeared. Other instances of the same mechanism: git's `ref -> ref` → `main`, Python `-> Type` hints in read files → `str`/`dict`, pip `>=x` → `=x`.

## The fix

1. **`cli/tools/filter.py`** — the filter header now uses `→` instead of `->`, so c3 never emits a shell-redirect metacharacter in its own output (eliminates the `Ntok` family entirely).
2. **`cli/hook_ghost_files.py`** — the cleanup hook previously only ran after `Bash`. It now also runs after `mcp__c3__c3_shell`, `mcp__c3__c3_read`, and `Read`, so ghosts from any tool's output (git refs, type hints, pip specifiers) are swept regardless of source.
3. **`cli/c3.py` (install-mcp)** — registers `hook_ghost_files` on the `Read` and `c3_read` matchers and adds a new `c3_shell` matcher block.

## Verified

- The broadened hook deletes a synthetic ghost when fed a `c3_shell` PostToolUse payload (clean UTF-8 stdin): `[c3:ghost-cleanup] Deleted 2 ghost file(s)…`.
- The filter header no longer contains `>`.
- `ruff` clean; `test_ghost_files.py` + `test_cli_smoke.py` pass (19).

## Activation

Logged under `[Unreleased]`. After merge, **re-run `c3 install-mcp`** (to register the new hook matchers) and **restart the MCP server** (to pick up the filter change). Happy to cut a `2.32.3` release once merged.

> Side note (not fixed here): the generated Windows hook commands use `shlex.quote`, which emits POSIX single quotes (`cmd /c '…'`) that cmd.exe treats literally. Hooks still work, but it's worth a follow-up to use Windows-appropriate quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
