### PR TITLE
fix(windows): c3 hooks never launched (cmd to cmd.exe) — completes PR #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The header now uses `→` (not a shell metacharacter). The ghost-file cleanup hook
   (`hook_ghost_files.py`) also now runs after `c3_shell`, `c3_read`, and `Read` — not
   just `Bash` — so ghosts from any tool's output (git `ref -> ref`, Python `-> Type`,
-  pip `>=x`) get swept. Re-run `c3 install-mcp` to register the new hook matchers.
+  pip `>=x`) get swept.
+- **Windows hooks never launched.** The generated PostToolUse/PreToolUse hook commands
+  used a bare `cmd /c` prefix, but Git Bash (which Claude Code uses to run hooks on
+  Windows) does not resolve bare `cmd` on PATH — so every c3 hook (enforcement, c3-signal,
+  output filter, ghost cleanup) silently failed to start. Changed the prefix to
+  `cmd.exe /c` (verified: the hook then runs and writes its signal file). Re-run
+  `c3 install-mcp` to regenerate the hook commands.
 
 ## [2.32.2] - 2026-06-09
 

--- a/cli/c3.py
+++ b/cli/c3.py
@@ -4921,8 +4921,14 @@ def cmd_install_mcp(args):
         # Build hook commands using the Python executable that runs c3.
         # On Windows, Claude Code executes hooks via /usr/bin/bash (Git Bash), which cannot
         # parse Windows absolute paths containing parentheses (e.g. "(C3)"). Prefix with
-        # "cmd /c" so cmd.exe handles path resolution instead of bash.
-        _hook_prefix = "cmd /c " if sys.platform == "win32" else ""
+        # cmd.exe so it handles path resolution instead of bash.
+        #
+        # Use "cmd.exe" WITH the extension, not bare "cmd": Git Bash does not resolve bare
+        # "cmd" on PATH, so the old "cmd /c …" prefix silently failed to launch any hook
+        # (verified: under bash, "cmd.exe /c '<py>' '<hook>'" runs and writes the signal
+        # file; "cmd /c …" returns "cmd: command not found"). The single-quoted paths are
+        # correct — bash strips them and re-quotes for cmd.exe, preserving spaces/parens.
+        _hook_prefix = "cmd.exe /c " if sys.platform == "win32" else ""
         hook_filter_cmd    = f"{_hook_prefix}{shlex.quote(sys.executable)} {shlex.quote(str(cli_dir / 'hook_filter.py'))}"
         hook_read_cmd      = f"{_hook_prefix}{shlex.quote(sys.executable)} {shlex.quote(str(cli_dir / 'hook_read.py'))}"
         hook_c3read_cmd    = f"{_hook_prefix}{shlex.quote(sys.executable)} {shlex.quote(str(cli_dir / 'hook_c3read.py'))}"


### PR DESCRIPTION
## Why a separate PR

This is the `cmd.exe` hook-launch fix that was committed to the PR #8 branch (`b345f80`) but **never landed on `main`**: PR #8's merge commit (`ad608a8`) has `e861345` as its second parent, so only the *first* commit (the ghost-filter change) was merged — the `cmd.exe` commit was pushed after the merge and got stranded. `main`'s `cli/c3.py` still had `cmd /c`. This cherry-picks the missing commit onto `main`.

## The fix

The generated PostToolUse/PreToolUse hook commands used a bare `cmd /c` prefix. Git Bash (Claude Code's Windows hook executor) does not resolve bare `cmd` on PATH, so **every c3 hook silently failed to launch** — enforcement, c3-signal, the output filter, and the ghost cleanup. Changed the prefix to `cmd.exe /c`.

Verified under bash: `cmd.exe /c '<py>' '<hook>'` runs the hook and writes its signal file (`rc=0`); `cmd /c …` returns `cmd: command not found`.

## Activation

Re-run `c3 install-mcp` to regenerate the hook commands, then restart Claude Code. Verify by running any c3 tool and confirming `.c3/last_c3_call.json` appears and updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
