### PR TITLE
feat: git branch awareness - scoped re-index + ledger/session/snapshot stamping (v2.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.35.0] - 2026-06-13
+
+### Added
+
+- **Git branch awareness across the index, ledger, sessions, and snapshots.** Working-tree state
+  is now centralized in a new `GitContext` helper (`services/git_context.py`): branch, HEAD sha,
+  upstream, ahead/behind, and dirty status from a single cached
+  `git status --branch --porcelain=v2` call, plus `changed_files()` / `dirty_files()` queries.
+  Worktrees and detached HEAD are handled. `EditLedger` and `VersionTracker` now route git-root
+  detection through it, de-duplicating two near-identical implementations.
+- **`BranchWatchAgent` — automatic, scoped re-index on branch changes.** A new background agent
+  detects HEAD/branch movement (checkout, switch, pull, merge — but *not* `git fetch`, which only
+  moves refs and leaves the working tree untouched) and queues a re-index of exactly the files
+  that differ between the old and new HEAD, restricted to files C3 already tracks. It also queues
+  files dirty on disk each cycle, catching edits made outside C3 (rebase, `git restore`, another
+  editor). Emits a **warning** notification on a branch switch and an **info** notification on a
+  same-branch HEAD move. Enabled by default (30s interval); tunable via `.c3/config.json` →
+  `agents.BranchWatch`.
+- **Branch stamping.** Edit-ledger entries, sessions, and context snapshots now record the git
+  `branch` + `head_sha` in effect at the time of the edit / session / snapshot.
+- **`c3_edits(action='history', branch=…)`** filters the audit trail to edits made on a given
+  branch; history output now shows the branch per entry.
+- **Snapshot restore warns on branch drift.** `c3_session(restore)` flags when the working tree
+  has moved to a different branch than the one the snapshot was captured on.
+
+### Changed
+
+- Context-snapshot capture and restore read fresh git state (bypassing the short TTL cache) so
+  the recorded and compared branch is always current.
+
+### Tests
+
+- New `tests/test_git_branch_awareness.py` exercises `GitContext`, `BranchWatchAgent`, ledger
+  branch stamping/filtering, and the snapshot branch-change warning against a real temporary git
+  repository (8 tests). Full suite: 389 passing.
+
 ## [2.34.0] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ C3 exposes 16 tools as a native MCP server. Your IDE calls them directly:
 | `c3_impact` | Blast-radius analysis before edits to shared symbols |
 | `c3_delegate` | Offload heavy work to local Ollama / Codex / Gemini / etc. |
 | `c3_agent` | Multi-step agentic workflows (review, investigate, refactor) |
-| `c3_edits` | Edit-ledger queries + version diffs + restore points |
+| `c3_edits` | Edit-ledger queries + version diffs + restore points + per-branch filter |
 | `c3_bitbucket` | Bitbucket Data Center integration — PRs, branches, builds, repo admin (v2.30.0) |
 | `c3_project` | Cross-project — discover & operate on other c3-installed projects; guarded writes (v2.31.0) |
 

--- a/cli/c3.py
+++ b/cli/c3.py
@@ -85,7 +85,7 @@ console = Console() if HAS_RICH else None
 # Config
 CONFIG_DIR = ".c3"
 CONFIG_FILE = ".c3/config.json"
-__version__ = "2.34.0"
+__version__ = "2.35.0"
 
 
 def _command_deps() -> CommandDeps:

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -604,9 +604,10 @@ async def c3_edit(file_path: str, old_string: str = "", new_string: str = "",
 async def c3_edits(action: str, file: str = "", change_type: str = "modified",
              summary: str = "", lines_changed: str = "", tags: str = "",
              limit: int = 50, since: str = "", edit_id: str = "",
-             tag: str = "", ctx: Context = None) -> str:
+             tag: str = "", branch: str = "", ctx: Context = None) -> str:
     """EDIT HISTORY — inspect the ledger. Different from c3_edit (which writes); this one reads.
-    actions: log (append entry), history (recent edits), versions (per-file), stats, tag (mark edit_id)."""
+    actions: log (append entry), history (recent edits), versions (per-file), stats, tag (mark edit_id).
+    branch: filter history to edits stamped with a given git branch."""
     svc = _svc(ctx)
 
     def finalize(name, args, resp, summ, **kw):
@@ -615,7 +616,7 @@ async def c3_edits(action: str, file: str = "", change_type: str = "modified",
     from cli.tools.edits import handle_edits
     return await asyncio.to_thread(handle_edits, action, file, change_type, summary,
                                    lines_changed, tags, limit, since, edit_id, tag,
-                                   svc, finalize)
+                                   svc, finalize, branch)
 
 
 @mcp.tool()

--- a/cli/tools/edits.py
+++ b/cli/tools/edits.py
@@ -3,7 +3,7 @@
 
 def handle_edits(action: str, file: str, change_type: str, summary: str,
                  lines_changed: str, tags: str, limit: int, since: str,
-                 edit_id: str, tag: str, svc, finalize) -> str:
+                 edit_id: str, tag: str, svc, finalize, branch: str = "") -> str:
     """Route c3_edits actions."""
     ledger = svc.edit_ledger
     if ledger is None:
@@ -64,12 +64,17 @@ def handle_edits(action: str, file: str, change_type: str, summary: str,
             file=file or None,
             limit=limit or 50,
             since=since or None,
+            branch=branch or None,
         )
         if not entries:
             return finalize("c3_edits", {"action": "history"}, "No edits found", "0 edits")
-        lines = [f"[edits:history] {len(entries)} entries" + (f" for {file}" if file else "")]
+        scope = (f" for {file}" if file else "") + (f" on {branch}" if branch else "")
+        lines = [f"[edits:history] {len(entries)} entries" + scope]
         for e in entries:
             ln = f"  {e['timestamp'][:19]} | {e['file']} {e['version']} | {e['change_type']} | {e['summary']}"
+            br = (e.get("git") or {}).get("branch")
+            if br:
+                ln += f" @{br}"
             if e.get("tags"):
                 ln += f" [{','.join(e['tags'])}]"
             lines.append(ln)

--- a/guide/tools.html
+++ b/guide/tools.html
@@ -1031,7 +1031,7 @@ c3_agent(workflow=<span class="str">'investigate'</span>, context=<span class="s
           <span class="tool-tagline">Edit ledger — history, versions, audit trail</span>
         </div>
         <div class="tool-card-body">
-          <p class="tool-desc">Access the edit ledger — a persistent append-only log of all file changes made through c3_edit. Provides history, version diffing, stats, and tagging. The ledger is also enriched in the background by the EditLedgerEnricherAgent.</p>
+          <p class="tool-desc">Access the edit ledger — a persistent append-only log of all file changes made through c3_edit. Provides history, version diffing, stats, and tagging. The ledger is also enriched in the background by the EditLedgerEnricherAgent. Since v2.35.0, each entry is stamped with the git <strong>branch</strong> and HEAD it was made on, and history can be filtered by branch.</p>
 
           <table class="params-table">
             <thead><tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
@@ -1054,6 +1054,12 @@ c3_agent(workflow=<span class="str">'investigate'</span>, context=<span class="s
                 <td class="param-default">"modified"</td>
                 <td class="param-desc">Change type for <code>log</code> action</td>
               </tr>
+              <tr>
+                <td class="param-name">branch</td>
+                <td class="param-type">string</td>
+                <td class="param-default">""</td>
+                <td class="param-desc">Filter <code>history</code> to edits stamped with this git branch <span class="badge">v2.35.0</span></td>
+              </tr>
             </tbody>
           </table>
 
@@ -1062,7 +1068,7 @@ c3_agent(workflow=<span class="str">'investigate'</span>, context=<span class="s
             <thead><tr><th>Action</th><th>Description</th></tr></thead>
             <tbody>
               <tr><td class="param-name">log</td><td class="param-desc">Manually log an edit to the ledger (normally done automatically by c3_edit)</td></tr>
-              <tr><td class="param-name">history</td><td class="param-desc">Show edit history (optionally filtered by file)</td></tr>
+              <tr><td class="param-name">history</td><td class="param-desc">Show edit history (optionally filtered by file and/or branch)</td></tr>
               <tr><td class="param-name">versions</td><td class="param-desc">Show version history for a specific file</td></tr>
               <tr><td class="param-name">stats</td><td class="param-desc">Aggregate stats: most-edited files, change frequency</td></tr>
               <tr><td class="param-name">tag</td><td class="param-desc">Tag an edit entry with a label</td></tr>
@@ -1077,7 +1083,10 @@ c3_edits(action=<span class="str">'history'</span>)
 c3_edits(action=<span class="str">'versions'</span>, file=<span class="str">'services/memory.py'</span>)
 
 <span class="com"># Ledger stats</span>
-c3_edits(action=<span class="str">'stats'</span>)</code></pre>
+c3_edits(action=<span class="str">'stats'</span>)
+
+<span class="com"># Edits made on a specific branch</span>
+c3_edits(action=<span class="str">'history'</span>, branch=<span class="str">'feature/x'</span>)</code></pre>
         </div>
       </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "code-context-control"
-version = "2.34.0"
+version = "2.35.0"
 description = "Local code-intelligence layer for AI coding tools (Claude Code, Codex, Gemini, Copilot). Retrieve less, read less, edit safer."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/services/agents.py
+++ b/services/agents.py
@@ -11,6 +11,7 @@ from collections import Counter
 from pathlib import Path
 
 from services.agent_base import BackgroundAgent  # noqa: F401 — re-exported for consumers
+from services.git_context import GitContext
 
 
 class IndexStalenessAgent(BackgroundAgent):
@@ -922,6 +923,137 @@ class FileMemoryAgent(BackgroundAgent):
         return status
 
 
+class BranchWatchAgent(BackgroundAgent):
+    """Detects branch / HEAD changes and queues a scoped, targeted re-index.
+
+    Change detection keys on the HEAD sha, so it fires on checkout, switch,
+    pull, and merge — but NOT on ``git fetch`` (which only moves remote refs;
+    the working tree is untouched). On a move it queues exactly the files that
+    differ between the old and new HEAD (from ``git diff``), restricted to files
+    C3 already tracks and that genuinely need re-indexing, then notifies
+    (warning on a branch switch, info on a same-branch HEAD move).
+
+    Every cycle it also queues tracked files that are dirty on disk, catching
+    edits made outside C3 (rebase, ``git restore``, another editor) that the
+    lazy mtime-on-access path would only notice later. The actual re-extraction
+    is done by FileMemoryAgent, which drains the same queue.
+    """
+
+    def __init__(self, file_memory, notifications, project_path,
+                 enabled=True, interval=30, max_queue=200, **kwargs):
+        super().__init__("BranchWatch", interval, notifications, enabled, **kwargs)
+        self.file_memory = file_memory
+        self.project_path = project_path
+        self.max_queue = max_queue
+        self._git = GitContext(project_path)
+        self._state_path = Path(project_path) / ".c3" / "branch_state.json"
+        self._loaded = False
+        self._last = {"branch": None, "head_sha": ""}
+
+    def _load_state(self):
+        if self._loaded:
+            return
+        self._loaded = True
+        try:
+            if self._state_path.exists():
+                data = json.loads(self._state_path.read_text(encoding="utf-8"))
+                self._last = {"branch": data.get("branch"),
+                              "head_sha": data.get("head_sha", "")}
+        except Exception:
+            pass
+
+    def _save_state(self, branch, head_sha):
+        self._last = {"branch": branch, "head_sha": head_sha}
+        try:
+            self._state_path.write_text(
+                json.dumps({"branch": branch, "head_sha": head_sha}),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
+
+    def _queue_changed(self, paths) -> int:
+        """Queue tracked files that still need re-indexing; return count queued.
+
+        Paths are compared slash-agnostically against the file-memory store and
+        filtered through ``needs_update`` so unchanged files (e.g. after a local
+        commit where the working tree already matches) are not re-processed.
+        """
+        if not paths:
+            return 0
+        tracked = {t.replace("\\", "/"): t for t in self.file_memory.list_tracked()}
+        queued = 0
+        for p in paths:
+            canonical = tracked.get(p.replace("\\", "/"))
+            if canonical is None:
+                continue
+            try:
+                if not self.file_memory.needs_update(canonical):
+                    continue
+            except Exception:
+                pass
+            self.file_memory.queue_for_update(canonical)
+            queued += 1
+            if queued >= self.max_queue:
+                break
+        return queued
+
+    def check(self):
+        st = self._git.state(force=True)
+        if not st.get("available"):
+            return False  # no git here — idle backoff
+        self._load_state()
+        cur_branch = st.get("branch")
+        cur_head = st.get("head_sha", "")
+        if not cur_head:
+            return False
+        prev_branch = self._last.get("branch")
+        prev_head = self._last.get("head_sha", "")
+
+        # Catch out-of-band working-tree edits every cycle.
+        dirty_queued = self._queue_changed(self._git.dirty_files())
+
+        # First run for this project — record the baseline without notifying.
+        if not prev_head:
+            self._save_state(cur_branch, cur_head)
+            return False if dirty_queued == 0 else None
+
+        if cur_head == prev_head and cur_branch == prev_branch:
+            return False if dirty_queued == 0 else None
+
+        # HEAD or branch moved — scope the re-index to what actually differs.
+        changed = self._git.changed_files(prev_head, cur_head)
+        if not changed:
+            # Old commit unreachable / diff failed — fall back to dirty set.
+            changed = self._git.dirty_files()
+        queued = self._queue_changed(changed)
+
+        switched = (cur_branch != prev_branch)
+        self._save_state(cur_branch, cur_head)
+
+        new_label = cur_branch or "(detached)"
+        if switched:
+            old_label = prev_branch or (prev_head[:8] if prev_head else "?")
+            self.notify(
+                "warning", "Branch changed",
+                f"{old_label} → {new_label}; queued {queued} tracked file(s) for re-index",
+                replace_if_unacked=True,
+            )
+        else:
+            self.notify(
+                "info", "Index refresh",
+                f"HEAD {prev_head[:8]}→{cur_head[:8]} on {new_label}; "
+                f"queued {queued} file(s) for re-index",
+                replace_if_unacked=True,
+            )
+        return None
+
+    def get_status(self) -> dict:
+        status = super().get_status()
+        status["branch"] = self._git.label()
+        return status
+
+
 class AutonomyPlannerAgent(BackgroundAgent):
     """Builds a prioritized autonomous action plan from recent tool telemetry."""
 
@@ -1507,6 +1639,19 @@ def create_agents(services, notifications, config=None, ollama=None) -> list:
                 **_cfg("FileMemory", {
                     "enabled": True, "interval": 120, "use_ai": False,
                     "ai_model": "gemma3n:latest", "max_files_per_cycle": 5,
+                }),
+            )
+        )
+
+    # BranchWatchAgent — needs file_memory's re-index queue.
+    if hasattr(services, 'file_memory') and services.file_memory:
+        agents.append(
+            BranchWatchAgent(
+                file_memory=services.file_memory,
+                notifications=notifications,
+                project_path=getattr(services, 'project_path', None),
+                **_cfg("BranchWatch", {
+                    "enabled": True, "interval": 30, "max_queue": 200,
                 }),
             )
         )

--- a/services/context_snapshot.py
+++ b/services/context_snapshot.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from core import count_tokens
+from services.git_context import GitContext
 
 # Max characters per file structural map stored in snapshot
 _FILE_MAP_MAX_CHARS = 600
@@ -21,6 +22,7 @@ class ContextSnapshot:
         self.project_path = Path(project_path)
         self.data_dir = self.project_path / data_dir
         self.data_dir.mkdir(parents=True, exist_ok=True)
+        self._git = GitContext(self.project_path)
 
     def capture(self, session_mgr, memory_store,
                 task_description: str = "",
@@ -88,11 +90,23 @@ class ContextSnapshot:
         # Context budget snapshot
         budget = session.get("context_budget", {})
 
+        # Git working-tree state — lets restore flag a branch change.
+        try:
+            gstate = self._git.state(force=True)
+            git_info = {
+                "branch": gstate.get("branch"),
+                "head_sha": gstate.get("head_sha", ""),
+                "detached": gstate.get("detached", False),
+            }
+        except Exception:
+            git_info = {"branch": None, "head_sha": "", "detached": False}
+
         snapshot = {
             "schema_version": 3,
             "snapshot_id": datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S"),
             "created": datetime.now(timezone.utc).isoformat(),
             "session_id": session_id,
+            "git": git_info,
             "task_description": task_description,
             "working_files": working_files or [],
             "custom_notes": custom_notes,
@@ -151,6 +165,20 @@ class ContextSnapshot:
         snap = self._load_snapshot(snapshot_id)
         if "error" in snap:
             return snap
+
+        # Flag when the working tree has moved off the branch this was taken on.
+        snap_git = snap.get("git") or {}
+        if snap_git.get("branch"):
+            try:
+                cur = self._git.state(force=True)
+                if (cur.get("available") and cur.get("branch")
+                        and cur["branch"] != snap_git["branch"]):
+                    snap["_branch_warning"] = (
+                        f"snapshot taken on '{snap_git['branch']}', "
+                        f"now on '{cur['branch']}'"
+                    )
+            except Exception:
+                pass
 
         # Enrich with live memory recall so cross-session facts are surfaced immediately
         if memory_store and snap.get("task_description"):
@@ -252,6 +280,13 @@ class ContextSnapshot:
         parts = [f"# Context Restore: {snap.get('task_description', 'N/A')}"]
         parts.append(f"Snapshot: {snap['snapshot_id']} | Session: {snap.get('session_id', '?')}")
 
+        git = snap.get("git") or {}
+        if git.get("head_sha"):
+            label = (git.get("branch") or "(detached)") + " @ " + git["head_sha"][:8]
+            parts.append(f"Branch: {label}")
+        if snap.get("_branch_warning"):
+            parts.append(f"\n⚠️ Branch changed since snapshot — {snap['_branch_warning']}")
+
         if snap.get("custom_notes"):
             parts.append(f"\n## Notes\n{snap['custom_notes']}")
 
@@ -328,6 +363,8 @@ class ContextSnapshot:
     def _compact_briefing(self, snap: dict) -> str:
         """Level 1: Compact briefing — top decisions + file list."""
         parts = [f"[restore:{snap['snapshot_id']}] {snap.get('task_description', '')}"]
+        if snap.get("_branch_warning"):
+            parts.append(f"⚠️ branch changed — {snap['_branch_warning']}")
 
         plans = snap.get("plans", [])
         if plans:

--- a/services/edit_ledger.py
+++ b/services/edit_ledger.py
@@ -15,6 +15,8 @@ from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 
+from services.git_context import GitContext
+
 
 class EditLedger:
     """Tracks every AI edit with version numbering and git context."""
@@ -23,7 +25,8 @@ class EditLedger:
         self.project_path = Path(project_path).resolve()
         self.ledger_file = self.project_path / ".c3" / "edit_ledger.jsonl"
         self.ledger_file.parent.mkdir(parents=True, exist_ok=True)
-        self._git_root = self._detect_git_root()
+        self._git = GitContext(self.project_path)
+        self._git_root = self._git.git_root
         # In-memory caches — loaded lazily on first use, updated on writes
         self._version_cache: dict[str, int] | None = None  # {file: max_version}
         self._total_count: int | None = None
@@ -75,7 +78,8 @@ class EditLedger:
         self._seq_counter += 1
 
         # Git info — single combined command when enabled
-        git_info = {"commit": "", "author": "", "subject": "", "dirty": False}
+        git_info = {"commit": "", "author": "", "subject": "", "dirty": False,
+                    "branch": None, "head_sha": ""}
         diff_summary = ""
         if include_git and self._git_root:
             git_info, diff_summary = self._git_combined(rel)
@@ -107,9 +111,10 @@ class EditLedger:
         return entry
 
     def get_history(self, file: str = None, limit: int = 50,
-                    since: str = None) -> list:
-        """Query edits, optionally filtered by file and/or time."""
-        results = self._load_merged(file_filter=file, since_filter=since)
+                    since: str = None, branch: str = None) -> list:
+        """Query edits, optionally filtered by file, time, and/or branch."""
+        results = self._load_merged(file_filter=file, since_filter=since,
+                                    branch_filter=branch)
         return results[-limit:]
 
     def get_file_versions(self, file: str) -> list:
@@ -208,31 +213,13 @@ class EditLedger:
                 continue
         return results[-limit:]
 
-    def _detect_git_root(self):
-        """Find git root directory."""
-        try:
-            kwargs = {}
-            if sys.platform == "win32":
-                kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
-            result = subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                cwd=self.project_path,
-                capture_output=True, text=True, timeout=3,
-                stdin=subprocess.DEVNULL,
-                **kwargs,
-            )
-            if result.returncode == 0:
-                return Path(result.stdout.strip()).resolve()
-        except Exception:
-            pass
-        return None
-
     def _git_combined(self, rel_path: str) -> tuple:
         """Capture git info + diff in a single subprocess call.
 
         Returns (git_info_dict, diff_summary_str).
         """
-        info = {"commit": "", "author": "", "subject": "", "dirty": False}
+        info = {"commit": "", "author": "", "subject": "", "dirty": False,
+                "branch": None, "head_sha": ""}
         diff_summary = ""
         abs_path = (self.project_path / rel_path).resolve()
         try:
@@ -296,11 +283,20 @@ class EditLedger:
         except Exception:
             pass
 
+        # Branch + HEAD from the cached GitContext (cheap; shared TTL cache).
+        try:
+            gstate = self._git.state()
+            info["branch"] = gstate.get("branch")
+            info["head_sha"] = gstate.get("head_sha", "")
+        except Exception:
+            pass
+
         return info, diff_summary
 
     # ── Async enrichment ──────────────────────────────────────────────
 
-    def _load_merged(self, file_filter: str = None, since_filter: str = None) -> list:
+    def _load_merged(self, file_filter: str = None, since_filter: str = None,
+                     branch_filter: str = None) -> list:
         """Read all base entries with any appended patches merged in.
 
         Patch entries are identified by having a 'target_id' field.
@@ -347,6 +343,8 @@ class EditLedger:
             if norm_file and entry.get("file") != norm_file:
                 continue
             if since_filter and entry.get("timestamp", "") < since_filter:
+                continue
+            if branch_filter and (entry.get("git") or {}).get("branch") != branch_filter:
                 continue
             results.append(entry)
         results.sort(key=lambda e: e.get("timestamp", ""))

--- a/services/git_context.py
+++ b/services/git_context.py
@@ -1,0 +1,243 @@
+"""GitContext — single source of truth for git working-tree state.
+
+Centralizes git-root detection and branch / HEAD / dirty queries so the rest
+of C3 does not re-implement subprocess plumbing (previously duplicated in
+``EditLedger`` and ``VersionTracker``). State is cached for a short TTL because
+several callers — the edit ledger, context snapshots, the branch watcher — ask
+for it in quick succession.
+
+All git calls use list-arg ``subprocess.run`` (no shell) with a timeout and the
+Windows ``CREATE_NO_WINDOW`` flag. The ``shell=True`` hang documented for the
+ledger's combined command does not apply to non-shell invocations, so the
+simple ``run(..., timeout=...)`` form is safe here.
+"""
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _git_kwargs() -> dict:
+    kwargs = {}
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+    return kwargs
+
+
+class GitContext:
+    """Cached accessor for the git working-tree state of a project path.
+
+    Branch awareness is deliberately content/ref-derived rather than persisted:
+    the index follows whatever HEAD currently points at. See ``state()`` for the
+    shape returned to callers.
+    """
+
+    def __init__(self, project_path, ttl: float = 3.0):
+        self.project_path = Path(project_path).resolve()
+        self._ttl = ttl
+        self._git_root = self._detect_git_root()
+        self._cache: dict | None = None
+        self._cache_time: float = 0.0
+
+    # ── git root ──────────────────────────────────────────────────────
+    @property
+    def git_root(self) -> Path | None:
+        return self._git_root
+
+    @property
+    def available(self) -> bool:
+        return self._git_root is not None
+
+    def _run(self, args: list, timeout: float = 3.0) -> tuple:
+        """Run a git command rooted at git_root (project_path fallback).
+
+        Returns (returncode, stdout, stderr); (None, '', '') on failure/timeout.
+        """
+        cwd = self._git_root or self.project_path
+        try:
+            proc = subprocess.run(
+                ["git", *args],
+                cwd=str(cwd),
+                capture_output=True, text=True, timeout=timeout,
+                stdin=subprocess.DEVNULL,
+                **_git_kwargs(),
+            )
+            return proc.returncode, proc.stdout or "", proc.stderr or ""
+        except Exception:
+            return None, "", ""
+
+    def _detect_git_root(self) -> Path | None:
+        try:
+            proc = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=str(self.project_path),
+                capture_output=True, text=True, timeout=3,
+                stdin=subprocess.DEVNULL,
+                **_git_kwargs(),
+            )
+            if proc.returncode == 0:
+                root = (proc.stdout or "").strip()
+                if root:
+                    return Path(root).resolve()
+        except Exception:
+            pass
+        return None
+
+    # ── working-tree state ────────────────────────────────────────────
+    @staticmethod
+    def _empty_state() -> dict:
+        return {
+            "available": False, "git_root": None, "branch": None,
+            "detached": False, "head_sha": "", "upstream": None,
+            "ahead": 0, "behind": 0, "dirty": False,
+        }
+
+    def state(self, force: bool = False) -> dict:
+        """Return cached working-tree state.
+
+        Keys: ``available``, ``git_root``, ``branch`` (None when detached),
+        ``detached``, ``head_sha`` (short), ``upstream``, ``ahead``, ``behind``,
+        ``dirty``. Cached for ``ttl`` seconds; pass ``force=True`` to refresh.
+        """
+        now = time.time()
+        if not force and self._cache is not None and (now - self._cache_time) < self._ttl:
+            return self._cache
+        self._cache = self._compute_state()
+        self._cache_time = now
+        return self._cache
+
+    def _compute_state(self) -> dict:
+        st = self._empty_state()
+        if not self._git_root:
+            return st
+        st["available"] = True
+        st["git_root"] = str(self._git_root)
+
+        rc, out, _ = self._run(["status", "--branch", "--porcelain=v2"])
+        if rc != 0:
+            # porcelain=v2 unsupported or command failed — degrade gracefully.
+            return self._fallback_state(st)
+
+        dirty = False
+        for line in out.splitlines():
+            if line.startswith("# branch.oid "):
+                sha = line[len("# branch.oid "):].strip()
+                if sha and sha != "(initial)":
+                    st["head_sha"] = sha[:12]
+            elif line.startswith("# branch.head "):
+                head = line[len("# branch.head "):].strip()
+                if head == "(detached)":
+                    st["detached"] = True
+                else:
+                    st["branch"] = head
+            elif line.startswith("# branch.upstream "):
+                st["upstream"] = line[len("# branch.upstream "):].strip()
+            elif line.startswith("# branch.ab "):
+                for token in line[len("# branch.ab "):].split():
+                    try:
+                        if token.startswith("+"):
+                            st["ahead"] = int(token[1:])
+                        elif token.startswith("-"):
+                            st["behind"] = int(token[1:])
+                    except ValueError:
+                        pass
+            elif line and not line.startswith("#"):
+                dirty = True
+        st["dirty"] = dirty
+        return st
+
+    def _fallback_state(self, st: dict) -> dict:
+        """Best-effort branch/HEAD for git versions without porcelain=v2."""
+        rc, out, _ = self._run(["rev-parse", "HEAD"])
+        if rc == 0 and out.strip():
+            st["head_sha"] = out.strip()[:12]
+        rc, out, _ = self._run(["rev-parse", "--abbrev-ref", "HEAD"])
+        if rc == 0:
+            head = out.strip()
+            if head == "HEAD":
+                st["detached"] = True
+            elif head:
+                st["branch"] = head
+        rc, out, _ = self._run(["status", "--porcelain"])
+        if rc == 0:
+            st["dirty"] = bool(out.strip())
+        return st
+
+    # ── convenience accessors ─────────────────────────────────────────
+    def branch(self) -> str | None:
+        return self.state().get("branch")
+
+    def head_sha(self) -> str:
+        return self.state().get("head_sha", "")
+
+    def label(self) -> str:
+        """Human-readable 'branch @ shortsha' (or '(detached) @ sha')."""
+        st = self.state()
+        if not st["available"]:
+            return "no-git"
+        name = st["branch"] or "(detached)"
+        sha = (st["head_sha"] or "")[:8]
+        return f"{name} @ {sha}" if sha else name
+
+    # ── change queries (scoped re-index support) ──────────────────────
+    def _to_project_rel(self, git_rel: str) -> str | None:
+        """Convert a git-root-relative path to project-relative POSIX form.
+
+        Returns None when the path lies outside ``project_path`` (e.g. a sibling
+        subdirectory of the repo, or another worktree) so callers never queue
+        files they do not track.
+        """
+        if not git_rel or not self._git_root:
+            return None
+        abs_path = (self._git_root / git_rel).resolve()
+        try:
+            return abs_path.relative_to(self.project_path).as_posix()
+        except Exception:
+            return None
+
+    def changed_files(self, old_sha: str, new_sha: str) -> list:
+        """Project-relative paths that differ between two commits.
+
+        Empty list if either sha is missing or the diff fails (e.g. the old
+        commit is no longer reachable) — callers should fall back to
+        ``dirty_files()`` in that case.
+        """
+        if not (old_sha and new_sha) or not self._git_root:
+            return []
+        rc, out, _ = self._run(["diff", "--name-only", f"{old_sha}..{new_sha}"])
+        if rc != 0:
+            return []
+        result = []
+        for line in out.splitlines():
+            rel = self._to_project_rel(line.strip())
+            if rel:
+                result.append(rel)
+        return result
+
+    def dirty_files(self) -> list:
+        """Project-relative paths with uncommitted working-tree changes.
+
+        Includes untracked files. Catches edits made outside C3 (other editors,
+        rebases, ``git restore``) that mtime-on-access would only notice later.
+        """
+        if not self._git_root:
+            return []
+        rc, out, _ = self._run(["status", "--porcelain"])
+        if rc != 0:
+            return []
+        result = []
+        for line in out.splitlines():
+            if len(line) <= 3:
+                continue
+            path = line[3:].strip()
+            # Renames render as 'old -> new'; index the new path.
+            if " -> " in path:
+                path = path.split(" -> ", 1)[1].strip()
+            # git quotes paths containing special characters.
+            if len(path) >= 2 and path.startswith('"') and path.endswith('"'):
+                path = path[1:-1]
+            rel = self._to_project_rel(path)
+            if rel:
+                result.append(rel)
+        return result

--- a/services/session_manager.py
+++ b/services/session_manager.py
@@ -16,6 +16,7 @@ from typing import Optional
 
 from core import count_tokens
 from core.ide import detect_ide, load_ide_config
+from services.git_context import GitContext
 
 
 class SessionManager:
@@ -49,6 +50,7 @@ class SessionManager:
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.current_session = None
         self.ollama_client = ollama_client
+        self._git = None
 
         # Analytics now in a dedicated directory
         analytics_dir = self.project_path / ".c3" / "analytics"
@@ -94,6 +96,20 @@ class SessionManager:
             ide_name = detect_ide(str(self.project_path))
         return ide_name or "claude-code"
 
+    def _git_state(self) -> dict:
+        """Current git branch/HEAD for stamping on the session (lazy, cached)."""
+        try:
+            if self._git is None:
+                self._git = GitContext(self.project_path)
+            st = self._git.state()
+            return {
+                "branch": st.get("branch"),
+                "head_sha": st.get("head_sha", ""),
+                "detached": st.get("detached", False),
+            }
+        except Exception:
+            return {"branch": None, "head_sha": "", "detached": False}
+
     def start_session(self, description: str = "", source_system: Optional[str] = None) -> dict:
         """Start a new session."""
         session_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
@@ -108,6 +124,7 @@ class SessionManager:
             "description": description,
             "source_system": source_system_value,
             "source_ide": source_ide,
+            "git": self._git_state(),
             "decisions": [],
             "files_touched": [],
             "key_changes": [],

--- a/services/version_tracker.py
+++ b/services/version_tracker.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from core.ide import get_profile
+from services.git_context import GitContext
 
 
 class VersionTracker:
@@ -20,7 +21,8 @@ class VersionTracker:
         self.ide_name = ide_name
         self.store_path = self.project_path / ".c3" / "version_tracker.json"
         self.store_path.parent.mkdir(parents=True, exist_ok=True)
-        self._git_root = self._detect_git_root()
+        self._git = GitContext(self.project_path)
+        self._git_root = self._git.git_root
         self.state = self._load_state()
 
     def scan(self, agent: str = "current", max_files: int | None = None) -> dict:
@@ -163,21 +165,6 @@ class VersionTracker:
         except Exception:
             return ""
 
-    def _detect_git_root(self) -> Path | None:
-        try:
-            result = subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                cwd=self.project_path,
-                capture_output=True,
-                text=True,
-                timeout=3,
-                check=True,
-            )
-            root = (result.stdout or "").strip()
-            return Path(root).resolve() if root else None
-        except Exception:
-            return None
-
     def _git_info(self, rel_path: str) -> dict:
         info = {
             "available": bool(self._git_root),
@@ -187,6 +174,7 @@ class VersionTracker:
             "author": "",
             "timestamp": 0,
             "subject": "",
+            "branch": None,
         }
         if not self._git_root:
             return info
@@ -249,6 +237,10 @@ class VersionTracker:
                     info["timestamp"] = 0
                 info["author"] = parts[2]
                 info["subject"] = parts[3]
+        except Exception:
+            pass
+        try:
+            info["branch"] = self._git.state().get("branch")
         except Exception:
             pass
         return info

--- a/tests/test_git_branch_awareness.py
+++ b/tests/test_git_branch_awareness.py
@@ -1,0 +1,162 @@
+"""Branch-awareness coverage: GitContext, BranchWatchAgent, ledger/session
+stamping, and snapshot branch-change warnings — exercised against a real
+temporary git repository.
+"""
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from services.agents import BranchWatchAgent
+from services.context_snapshot import ContextSnapshot
+from services.edit_ledger import EditLedger
+from services.file_memory import FileMemoryStore
+from services.git_context import GitContext
+from services.notifications import NotificationStore
+
+
+def _git(cwd, *args):
+    kwargs = {}
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd),
+        capture_output=True, text=True, check=True, **kwargs,
+    )
+
+
+class _StubSession:
+    def __init__(self):
+        self.current_session = {
+            "id": "sess-1",
+            "decisions": [],
+            "files_touched": [{"file": "mod.py", "type": "code", "summary": "x"}],
+            "context_notes": [],
+            "context_budget": {"response_tokens": 1, "call_count": 1},
+        }
+
+
+class _StubMemory:
+    facts = []
+
+    def recall(self, *args, **kwargs):
+        return []
+
+
+@unittest.skipUnless(shutil.which("git"), "git not available")
+class TestBranchAwareness(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.project = Path(self.tmp.name)
+        (self.project / ".c3").mkdir(exist_ok=True)
+        _git(self.project, "init")
+        _git(self.project, "config", "user.email", "t@example.com")
+        _git(self.project, "config", "user.name", "Test")
+        _git(self.project, "config", "commit.gpgsign", "false")
+        (self.project / "mod.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+        _git(self.project, "add", "-A")
+        _git(self.project, "commit", "-m", "init")
+        _git(self.project, "branch", "-M", "main")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    # ── Tier 0: GitContext ────────────────────────────────────────────
+    def test_state_reports_branch_and_dirty(self):
+        g = GitContext(self.project)
+        st = g.state()
+        self.assertTrue(st["available"])
+        self.assertEqual(st["branch"], "main")
+        self.assertTrue(st["head_sha"])
+        self.assertFalse(st["dirty"])
+        self.assertFalse(st["detached"])
+
+        (self.project / "mod.py").write_text("def a():\n    return 2\n", encoding="utf-8")
+        st2 = g.state(force=True)
+        self.assertTrue(st2["dirty"])
+        self.assertIn("mod.py", g.dirty_files())
+
+    def test_changed_files_between_commits(self):
+        g = GitContext(self.project)
+        old = g.head_sha()
+        _git(self.project, "checkout", "-b", "feature")
+        (self.project / "mod.py").write_text("def a():\n    return 99\n", encoding="utf-8")
+        _git(self.project, "add", "-A")
+        _git(self.project, "commit", "-m", "change")
+        new = g.state(force=True)["head_sha"]
+        self.assertNotEqual(old, new)
+        self.assertEqual(g.branch(), "feature")
+        self.assertIn("mod.py", g.changed_files(old, new))
+
+    def test_detached_head_does_not_crash(self):
+        g = GitContext(self.project)
+        head = g.head_sha()
+        _git(self.project, "checkout", head)
+        st = g.state(force=True)
+        self.assertTrue(st["available"])
+        self.assertTrue(st["detached"])
+        self.assertIsNone(st["branch"])
+
+    # ── Tier 2/3: BranchWatchAgent ────────────────────────────────────
+    def test_branch_switch_queues_scoped_reindex(self):
+        fm = FileMemoryStore(str(self.project))
+        fm.update("mod.py")
+        notifs = NotificationStore(str(self.project))
+        agent = BranchWatchAgent(fm, notifs, str(self.project), enabled=False)
+
+        agent.check()  # baseline — records HEAD, no notification
+        self.assertEqual([n["title"] for n in notifs.get_history()], [])
+
+        _git(self.project, "checkout", "-b", "feature")
+        (self.project / "mod.py").write_text("def a():\n    return 99\n", encoding="utf-8")
+        _git(self.project, "add", "-A")
+        _git(self.project, "commit", "-m", "change")
+
+        agent.check()  # detect switch
+        self.assertIn("Branch changed", [n["title"] for n in notifs.get_history()])
+        self.assertIn("mod.py", fm.drain_queue())
+
+    def test_fetch_like_noop_does_not_notify(self):
+        fm = FileMemoryStore(str(self.project))
+        fm.update("mod.py")
+        notifs = NotificationStore(str(self.project))
+        agent = BranchWatchAgent(fm, notifs, str(self.project), enabled=False)
+        agent.check()   # baseline
+        agent.check()   # no ref movement, clean tree
+        self.assertEqual([n["title"] for n in notifs.get_history()], [])
+
+    def test_dirty_file_fast_path_queues_outside_edit(self):
+        fm = FileMemoryStore(str(self.project))
+        fm.update("mod.py")
+        notifs = NotificationStore(str(self.project))
+        agent = BranchWatchAgent(fm, notifs, str(self.project), enabled=False)
+        agent.check()  # baseline
+        # Edit made "outside" C3 (no ledger/queue), HEAD unchanged.
+        (self.project / "mod.py").write_text("def a():\n    return 7\n", encoding="utf-8")
+        agent.check()
+        self.assertIn("mod.py", fm.drain_queue())
+
+    # ── Tier 1: ledger stamping + filter ──────────────────────────────
+    def test_ledger_stamps_branch_and_filters(self):
+        ledger = EditLedger(str(self.project))
+        entry = ledger.log_edit("mod.py", "modified", "tweak")
+        self.assertEqual(entry["git"]["branch"], "main")
+        self.assertTrue(entry["git"]["head_sha"])
+
+        hist = ledger.get_history(branch="main")
+        self.assertTrue(any(e["id"] == entry["id"] for e in hist))
+        self.assertEqual(ledger.get_history(branch="does-not-exist"), [])
+
+    # ── Tier 1: snapshot branch warning ───────────────────────────────
+    def test_snapshot_warns_on_branch_change(self):
+        snap = ContextSnapshot(str(self.project))
+        snap.capture(_StubSession(), _StubMemory(), task_description="task")
+        _git(self.project, "checkout", "-b", "feature")
+        restored = snap.restore("latest")
+        self.assertIn("Branch changed", restored["briefing"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds git **branch awareness** to C3 so the index, edit ledger, sessions, and snapshots follow `HEAD`/branch changes instead of being branch-blind. Implemented in four tiers.

## What changed

**Tier 0 — `GitContext` (`services/git_context.py`, new)**
Centralizes working-tree state: branch, HEAD sha, upstream, ahead/behind, dirty — from one cached `git status --branch --porcelain=v2` call — plus `changed_files()` / `dirty_files()` (project-relative; worktree + detached-HEAD safe). `EditLedger` and `VersionTracker` now route git-root detection through it, removing two duplicated `_detect_git_root` implementations.

**Tier 2 — `BranchWatchAgent` (scoped re-index)**
Background agent keyed on the HEAD sha: fires on checkout/switch/pull/merge but **not** `git fetch`. Queues a re-index of only the files that differ between old and new HEAD (∩ tracked ∩ `needs_update`). Notifies **warning** on a branch switch, **info** on a same-branch HEAD move. Enabled by default (30s); tunable via `.c3/config.json` → `agents.BranchWatch`.

**Tier 1 — branch stamping**
- Ledger entries, sessions, and snapshots record `branch` + `head_sha`.
- `c3_edits(action='history', branch=…)` filters the audit trail; history shows the branch per entry.
- Snapshot restore warns when the working tree moved off the snapshot's branch.

**Tier 3 — dirty fast-path + worktree/detached correctness**
`BranchWatchAgent` also queues tracked files dirty on disk each cycle (catches edits made outside C3 — rebase, `git restore`, other editors). Detached HEAD handled and tested.

## Tests
New `tests/test_git_branch_awareness.py` (8 tests) against a real temporary git repo. Full suite **389 passing**, ruff clean.

## Release
Bumps to **v2.35.0** (`pyproject.toml` + `cli/c3.py`); CHANGELOG, README, and in-app guide updated. Tagging `v2.35.0` after merge triggers the automated PyPI publish + GitHub release via `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
