### PR TITLE
fix: force UTF-8 console so Oracle server starts on Windows cp1252

### DIFF
--- a/oracle/oracle_server.py
+++ b/oracle/oracle_server.py
@@ -825,8 +825,19 @@ def _is_oracle_running(port: int) -> bool:
         return False
 
 
+def _force_utf8_console() -> None:
+    """Make stdout/stderr UTF-8 so banner/log output can't crash on legacy
+    Windows code pages (cp1252 raises UnicodeEncodeError on chars like '→')."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError, OSError):
+            pass
+
+
 def run_oracle(port: int = None, open_browser: bool = None):
     """Main entry point for Oracle server."""
+    _force_utf8_console()
     _init_services()
 
     cfg = load_config()


### PR DESCRIPTION
## Summary

Fixes a Windows-only startup crash. The Oracle server's banner prints a `→` character that raises `UnicodeEncodeError` on consoles/pipes using the **cp1252** code page (observed on Python 3.14), so `python oracle/oracle_server.py` never finished booting — it required a `PYTHONIOENCODING=utf-8` workaround.

## Fix

`_force_utf8_console()` in `oracle/oracle_server.py`, called first in `run_oracle()`, reconfigures `stdout`/`stderr` to UTF-8 with `errors="replace"`. One place fixes the two startup banners **and** the logging `StreamHandler`, and won't crash if a stream can't be reconfigured.

## Testing

Started the server **without** the `PYTHONIOENCODING=utf-8` workaround that was previously required — it now boots cleanly and `GET /api/health` returns ok. Banner renders correctly:

```
Oracle Memory Agent  →  http://localhost:3331  (model: gpt-oss:120b-cloud)
Oracle Discovery MCP  →  http://127.0.0.1:3332/mcp  (auth: bearer)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
