### PR TITLE
fix: reword circuit breaker docstrings to satisfy windows-reliability open() guard

### DIFF
--- a/services/circuit_breaker.py
+++ b/services/circuit_breaker.py
@@ -17,7 +17,7 @@ import time
 
 
 class CircuitBreaker:
-    """Consecutive-failure breaker: closed -> open (after N fails) -> half-open (after cooldown)."""
+    """Consecutive-failure breaker: closed, opens after N fails, half-opens to probe after a cooldown."""
 
     def __init__(
         self,
@@ -55,9 +55,9 @@ class CircuitBreaker:
     def record_failure(self) -> bool:
         """Count a failed call.
 
-        Returns True iff this failure *just* tripped the breaker open (callers
-        can use that edge to emit a one-shot notification). A failed half-open
-        probe restarts the cooldown but does not re-trip.
+        Returns True iff this failure *just* tripped the breaker into the open
+        state, so callers can emit a one-shot notification on that edge. A failed
+        half-open probe restarts the cooldown but does not re-trip.
         """
         with self._lock:
             self._failures += 1

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -10,7 +10,7 @@ def test_closed_until_threshold_then_opens():
     assert br.record_failure() is False  # 1
     assert br.record_failure() is False  # 2
     assert br.allow()                    # still closed below threshold
-    assert br.record_failure() is True   # 3 -> trips open (edge)
+    assert br.record_failure() is True   # 3 -> trips it open at threshold
     assert not br.allow()                # open, within cooldown
     assert br.is_open
 


### PR DESCRIPTION
Follow-up to #22. `test_no_text_open_without_encoding` walks paren-depth from a bare `open(` regex and flagged prose in the new files — `open (after N fails)`, `half-open (after cooldown)`, `trips open (edge)` — as text-mode `open()` calls missing `encoding=`. No real `open()` calls were involved.

Reworded the two docstrings + one comment so no `open (` sequence remains. Full suite now **479 passed** locally (was 478 passed / 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)